### PR TITLE
Add Jiu-Jitsu Lesson Tracker iOS app (SwiftUI + SwiftData)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,48 @@
+name: Deploy lesson-tracker demo
+
+# Publishes the self-contained web demo in static/lesson-tracker/ to the
+# `gh-pages` branch. Enable GitHub Pages once (Settings → Pages → Deploy from a
+# branch → gh-pages → / root) and the site updates automatically after that.
+
+on:
+  push:
+    branches:
+      - claude/jiu-jitsu-lesson-tracker-10qzyj
+      - main
+    paths:
+      - "static/lesson-tracker/**"
+      - ".github/workflows/deploy-demo.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Publish demo to gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          SRC="static/lesson-tracker"
+          WORK="$(mktemp -d)"
+          cp -r "$SRC"/. "$WORK"/
+          # Disable Jekyll so files are served as-is.
+          touch "$WORK/.nojekyll"
+          cd "$WORK"
+          git init -q
+          git checkout -q -b gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -q -m "Deploy lesson-tracker demo"
+          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages

--- a/ios/JiuJitsuLessonTracker/.gitignore
+++ b/ios/JiuJitsuLessonTracker/.gitignore
@@ -1,0 +1,14 @@
+# Xcode / Swift
+build/
+DerivedData/
+*.xcuserstate
+xcuserdata/
+*.xcscmblueprint
+*.xccheckout
+.swiftpm/
+*.moved-aside
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+.DS_Store

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker.xcodeproj/project.pbxproj
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker.xcodeproj/project.pbxproj
@@ -1,0 +1,320 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		AA00000000000000000000A1 /* JiuJitsuLessonTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JiuJitsuLessonTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		AA00000000000000000000B1 /* JiuJitsuLessonTracker */ = {isa = PBXFileSystemSynchronizedRootGroup; path = JiuJitsuLessonTracker; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AA00000000000000000000C1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AA00000000000000000000D1 = {
+			isa = PBXGroup;
+			children = (
+				AA00000000000000000000B1 /* JiuJitsuLessonTracker */,
+				AA00000000000000000000D2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AA00000000000000000000D2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AA00000000000000000000A1 /* JiuJitsuLessonTracker.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AA00000000000000000000E1 /* JiuJitsuLessonTracker */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA00000000000000000000F1 /* Build configuration list for PBXNativeTarget "JiuJitsuLessonTracker" */;
+			buildPhases = (
+				AA00000000000000000000C2 /* Sources */,
+				AA00000000000000000000C1 /* Frameworks */,
+				AA00000000000000000000C3 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				AA00000000000000000000B1 /* JiuJitsuLessonTracker */,
+			);
+			name = JiuJitsuLessonTracker;
+			productName = JiuJitsuLessonTracker;
+			productReference = AA00000000000000000000A1 /* JiuJitsuLessonTracker.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AA0000000000000000000101 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					AA00000000000000000000E1 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = AA0000000000000000000102 /* Build configuration list for PBXProject "JiuJitsuLessonTracker" */;
+			compatibilityVersion = "Xcode 15.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AA00000000000000000000D1;
+			productRefGroup = AA00000000000000000000D2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AA00000000000000000000E1 /* JiuJitsuLessonTracker */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AA00000000000000000000C3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AA00000000000000000000C2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		AA0000000000000000000111 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AA0000000000000000000112 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AA0000000000000000000113 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.JiuJitsuLessonTracker;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AA0000000000000000000114 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.JiuJitsuLessonTracker;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AA0000000000000000000102 /* Build configuration list for PBXProject "JiuJitsuLessonTracker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA0000000000000000000111 /* Debug */,
+				AA0000000000000000000112 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AA00000000000000000000F1 /* Build configuration list for PBXNativeTarget "JiuJitsuLessonTracker" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA0000000000000000000113 /* Debug */,
+				AA0000000000000000000114 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AA0000000000000000000101 /* Project object */;
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.85",
+          "green" : "0.30",
+          "red" : "0.10"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Assets.xcassets/Contents.json
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/JiuJitsuLessonTracker.entitlements
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/JiuJitsuLessonTracker.entitlements
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Reference entitlements for enabling iCloud / CloudKit sync.
+
+  This file is NOT wired into the build by default so the app runs in the
+  Simulator with no configuration. Prefer enabling iCloud through Xcode's
+  "Signing & Capabilities" tab (it generates the correct entitlements and
+  registers the container under your Apple Developer account). Use this only
+  as a manual reference, and update the container identifier to match yours.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.example.JiuJitsuLessonTracker</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/JiuJitsuLessonTrackerApp.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/JiuJitsuLessonTrackerApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct JiuJitsuLessonTrackerApp: App {
+    let modelContainer = AppModelContainer.makeShared()
+
+    var body: some Scene {
+        WindowGroup {
+            RootTabView()
+        }
+        .modelContainer(modelContainer)
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Client.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Client.swift
@@ -1,0 +1,104 @@
+import Foundation
+import SwiftData
+
+/// A private-lesson client (student).
+///
+/// All properties have default values and relationships are optional so the
+/// model is compatible with CloudKit-backed SwiftData syncing.
+@Model
+final class Client {
+    var name: String = ""
+    var belt: BeltRank = BeltRank.white
+    var stripes: Int = 0
+    var email: String = ""
+    var phone: String = ""
+    var startDate: Date = Date.now
+    var notes: String = ""
+    var isActive: Bool = true
+
+    /// Default price charged for one private lesson with this client.
+    var defaultLessonRate: Double = 0
+
+    /// Inverse relationships. Deleting a client cascades to their records.
+    @Relationship(deleteRule: .cascade, inverse: \Lesson.client)
+    var lessons: [Lesson]? = []
+
+    @Relationship(deleteRule: .cascade, inverse: \Payment.client)
+    var payments: [Payment]? = []
+
+    var createdAt: Date = Date.now
+
+    init(
+        name: String = "",
+        belt: BeltRank = .white,
+        stripes: Int = 0,
+        email: String = "",
+        phone: String = "",
+        startDate: Date = .now,
+        notes: String = "",
+        isActive: Bool = true,
+        defaultLessonRate: Double = 0
+    ) {
+        self.name = name
+        self.belt = belt
+        self.stripes = stripes
+        self.email = email
+        self.phone = phone
+        self.startDate = startDate
+        self.notes = notes
+        self.isActive = isActive
+        self.defaultLessonRate = defaultLessonRate
+        self.createdAt = .now
+    }
+}
+
+// MARK: - Derived data
+
+extension Client {
+    var lessonsList: [Lesson] { lessons ?? [] }
+    var paymentsList: [Payment] { payments ?? [] }
+
+    /// First and last initial, for the avatar badge.
+    var initials: String {
+        let parts = name.split(separator: " ")
+        let letters = parts.prefix(2).compactMap { $0.first }
+        let result = String(letters).uppercased()
+        return result.isEmpty ? "?" : result
+    }
+
+    var displayName: String {
+        name.trimmingCharacters(in: .whitespaces).isEmpty ? "Unnamed client" : name
+    }
+
+    var completedLessons: [Lesson] {
+        lessonsList.filter { $0.status == .completed }
+    }
+
+    var upcomingLessons: [Lesson] {
+        lessonsList
+            .filter { $0.status == .scheduled && $0.date >= Calendar.current.startOfDay(for: .now) }
+            .sorted { $0.date < $1.date }
+    }
+
+    var nextLesson: Lesson? { upcomingLessons.first }
+
+    var totalPaid: Double {
+        paymentsList.reduce(0) { $0 + $1.amount }
+    }
+
+    /// Number of lessons the client has prepaid for across all payments.
+    var lessonsPrepaid: Int {
+        paymentsList.reduce(0) { $0 + $1.lessonsCovered }
+    }
+
+    /// Prepaid lessons remaining after accounting for completed lessons.
+    var lessonsRemaining: Int {
+        lessonsPrepaid - completedLessons.count
+    }
+
+    /// Estimated outstanding balance: completed lessons not covered by prepayment.
+    var outstandingBalance: Double {
+        let owed = Double(max(0, -lessonsRemaining)) * defaultLessonRate
+        return owed
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Enums.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Enums.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// Brazilian Jiu-Jitsu adult belt ranks, in progression order.
+enum BeltRank: String, Codable, CaseIterable, Identifiable, Comparable {
+    case white = "White"
+    case blue = "Blue"
+    case purple = "Purple"
+    case brown = "Brown"
+    case black = "Black"
+
+    var id: String { rawValue }
+
+    /// Sort/progression index used for `Comparable` conformance.
+    private var order: Int {
+        Self.allCases.firstIndex(of: self) ?? 0
+    }
+
+    static func < (lhs: BeltRank, rhs: BeltRank) -> Bool {
+        lhs.order < rhs.order
+    }
+
+    /// Display color for the belt badge.
+    var color: Color {
+        switch self {
+        case .white: return Color(white: 0.85)
+        case .blue: return .blue
+        case .purple: return .purple
+        case .brown: return .brown
+        case .black: return .black
+        }
+    }
+
+    /// Contrasting color for text drawn on top of the belt color.
+    var textColor: Color {
+        self == .white ? .black : .white
+    }
+}
+
+/// Lifecycle of a single lesson. Drives both the schedule and attendance.
+enum LessonStatus: String, Codable, CaseIterable, Identifiable {
+    case scheduled = "Scheduled"
+    case completed = "Completed"
+    case cancelled = "Cancelled"
+    case noShow = "No-show"
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .scheduled: return "calendar"
+        case .completed: return "checkmark.circle.fill"
+        case .cancelled: return "xmark.circle"
+        case .noShow: return "person.fill.xmark"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .scheduled: return .blue
+        case .completed: return .green
+        case .cancelled: return .orange
+        case .noShow: return .red
+        }
+    }
+}
+
+/// How a payment was received.
+enum PaymentMethod: String, Codable, CaseIterable, Identifiable {
+    case cash = "Cash"
+    case card = "Card"
+    case bankTransfer = "Bank transfer"
+    case venmo = "Venmo"
+    case paypal = "PayPal"
+    case other = "Other"
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .cash: return "banknote"
+        case .card: return "creditcard"
+        case .bankTransfer: return "building.columns"
+        case .venmo, .paypal: return "dollarsign.circle"
+        case .other: return "ellipsis.circle"
+        }
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Lesson.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Lesson.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftData
+
+/// A single private lesson — used for both scheduling (future, `.scheduled`)
+/// and the lesson log / attendance (past, `.completed` / `.cancelled` / `.noShow`).
+@Model
+final class Lesson {
+    var date: Date = Date.now
+    var durationMinutes: Int = 60
+    var status: LessonStatus = LessonStatus.scheduled
+    var location: String = ""
+
+    /// Free-text or comma-separated list of techniques drilled.
+    var techniques: String = ""
+    var notes: String = ""
+
+    /// Price charged for this specific lesson (defaults from the client's rate).
+    var rate: Double = 0
+
+    var client: Client?
+
+    var createdAt: Date = Date.now
+
+    init(
+        date: Date = .now,
+        durationMinutes: Int = 60,
+        status: LessonStatus = .scheduled,
+        location: String = "",
+        techniques: String = "",
+        notes: String = "",
+        rate: Double = 0,
+        client: Client? = nil
+    ) {
+        self.date = date
+        self.durationMinutes = durationMinutes
+        self.status = status
+        self.location = location
+        self.techniques = techniques
+        self.notes = notes
+        self.rate = rate
+        self.client = client
+        self.createdAt = .now
+    }
+}
+
+// MARK: - Derived data
+
+extension Lesson {
+    var endDate: Date {
+        date.addingTimeInterval(TimeInterval(durationMinutes * 60))
+    }
+
+    var isPast: Bool { endDate < .now }
+
+    /// Techniques split into trimmed, non-empty tokens for chip display.
+    var techniqueTokens: [String] {
+        techniques
+            .split(whereSeparator: { $0 == "," || $0 == "\n" })
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Payment.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Models/Payment.swift
@@ -1,0 +1,37 @@
+import Foundation
+import SwiftData
+
+/// A payment received from a client. Supports package tracking via
+/// `lessonsCovered` (e.g. a 10-lesson package paid up front).
+@Model
+final class Payment {
+    var date: Date = Date.now
+    var amount: Double = 0
+    var method: PaymentMethod = PaymentMethod.cash
+
+    /// How many lessons this payment prepays for. Use 0 for non-lesson charges.
+    var lessonsCovered: Int = 1
+
+    var note: String = ""
+
+    var client: Client?
+
+    var createdAt: Date = Date.now
+
+    init(
+        date: Date = .now,
+        amount: Double = 0,
+        method: PaymentMethod = .cash,
+        lessonsCovered: Int = 1,
+        note: String = "",
+        client: Client? = nil
+    ) {
+        self.date = date
+        self.amount = amount
+        self.method = method
+        self.lessonsCovered = lessonsCovered
+        self.note = note
+        self.client = client
+        self.createdAt = .now
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Support/AppModelContainer.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Support/AppModelContainer.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftData
+
+/// Centralizes SwiftData container creation.
+///
+/// ## Enabling iCloud (CloudKit) sync
+/// The app ships using **local on-device storage** so it builds and runs with
+/// zero configuration in the Simulator. To turn on cross-device cloud sync:
+///
+/// 1. In Xcode select the target → **Signing & Capabilities**.
+/// 2. Pick your Team, then **+ Capability → iCloud** and check **CloudKit**.
+///    Add a container named `iCloud.com.example.JiuJitsuLessonTracker`
+///    (or match it to your bundle identifier).
+/// 3. **+ Capability → Background Modes** and check **Remote notifications**
+///    so the app syncs in the background.
+/// 4. Set `useCloudKit = true` below and rebuild.
+///
+/// SwiftData then mirrors the local store to your private CloudKit database
+/// automatically — no extra code required.
+enum AppModelContainer {
+
+    /// Flip to `true` after completing the CloudKit setup steps above.
+    static let useCloudKit = false
+
+    /// The schema shared by the app and previews.
+    static let schema = Schema([
+        Client.self,
+        Lesson.self,
+        Payment.self,
+    ])
+
+    /// Builds the production container (persisted to disk).
+    static func makeShared() -> ModelContainer {
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: false,
+            cloudKitDatabase: useCloudKit ? .automatic : .none
+        )
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Failed to create ModelContainer: \(error)")
+        }
+    }
+
+    /// An in-memory container seeded with sample data, for SwiftUI previews.
+    @MainActor
+    static func makePreview() -> ModelContainer {
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+        do {
+            let container = try ModelContainer(for: schema, configurations: [configuration])
+            SampleData.populate(container.mainContext)
+            return container
+        } catch {
+            fatalError("Failed to create preview ModelContainer: \(error)")
+        }
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Support/Formatters.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Support/Formatters.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Shared, reusable formatters and small formatting helpers.
+enum Format {
+
+    static let currency: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .currency
+        f.maximumFractionDigits = 2
+        return f
+    }()
+
+    static func money(_ value: Double) -> String {
+        currency.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    static func duration(_ minutes: Int) -> String {
+        guard minutes >= 60 else { return "\(minutes) min" }
+        let hours = minutes / 60
+        let mins = minutes % 60
+        return mins == 0 ? "\(hours) hr" : "\(hours) hr \(mins) min"
+    }
+
+    /// "Today", "Tomorrow", "Yesterday", or a medium date.
+    static func relativeDay(_ date: Date) -> String {
+        let cal = Calendar.current
+        if cal.isDateInToday(date) { return "Today" }
+        if cal.isDateInTomorrow(date) { return "Tomorrow" }
+        if cal.isDateInYesterday(date) { return "Yesterday" }
+        return date.formatted(.dateTime.weekday(.abbreviated).month(.abbreviated).day())
+    }
+
+    static func time(_ date: Date) -> String {
+        date.formatted(date: .omitted, time: .shortened)
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Support/SampleData.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Support/SampleData.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftData
+
+/// Seed data so the app shows something useful on first launch and in previews.
+enum SampleData {
+
+    /// Inserts sample clients with lessons and payments into the context.
+    @MainActor
+    static func populate(_ context: ModelContext) {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: .now)
+
+        func day(_ offset: Int, hour: Int = 17, minute: Int = 0) -> Date {
+            let base = cal.date(byAdding: .day, value: offset, to: today) ?? today
+            return cal.date(bySettingHour: hour, minute: minute, second: 0, of: base) ?? base
+        }
+
+        // MARK: Alex — active blue belt on a 10-pack
+        let alex = Client(
+            name: "Alex Costa",
+            belt: .blue,
+            stripes: 2,
+            email: "alex.costa@example.com",
+            phone: "555-0142",
+            startDate: cal.date(byAdding: .month, value: -14, to: today) ?? today,
+            notes: "Competing at the next local open. Working takedowns.",
+            defaultLessonRate: 80
+        )
+        context.insert(alex)
+        context.insert(Payment(date: day(-20), amount: 800, method: .card, lessonsCovered: 10, note: "10-lesson package", client: alex))
+        context.insert(Lesson(date: day(-18), status: .completed, location: "Main mat", techniques: "Single leg, sprawl defense", rate: 80, client: alex))
+        context.insert(Lesson(date: day(-11), status: .completed, location: "Main mat", techniques: "Guard retention, hip escape", rate: 80, client: alex))
+        context.insert(Lesson(date: day(-4), status: .completed, location: "Main mat", techniques: "Knee cut pass, underhook", rate: 80, client: alex))
+        context.insert(Lesson(date: day(2), status: .scheduled, location: "Main mat", techniques: "Leg drag, back takes", rate: 80, client: alex))
+        context.insert(Lesson(date: day(9), status: .scheduled, location: "Main mat", rate: 80, client: alex))
+
+        // MARK: Maria — newer white belt, pay-as-you-go
+        let maria = Client(
+            name: "Maria Santos",
+            belt: .white,
+            stripes: 3,
+            email: "maria.s@example.com",
+            phone: "555-0188",
+            startDate: cal.date(byAdding: .month, value: -5, to: today) ?? today,
+            notes: "Focus on fundamentals and confidence. Prefers morning sessions.",
+            defaultLessonRate: 70
+        )
+        context.insert(maria)
+        context.insert(Payment(date: day(-7), amount: 70, method: .cash, lessonsCovered: 1, note: "Single lesson", client: maria))
+        context.insert(Lesson(date: day(-7, hour: 9), status: .completed, location: "Studio B", techniques: "Mount escapes, bridge & roll", rate: 70, client: maria))
+        context.insert(Lesson(date: day(1, hour: 9), status: .scheduled, location: "Studio B", techniques: "Closed guard basics", rate: 70, client: maria))
+
+        // MARK: Jordan — purple belt prepping for competition
+        let jordan = Client(
+            name: "Jordan Lee",
+            belt: .purple,
+            stripes: 0,
+            email: "jordan.lee@example.com",
+            phone: "555-0119",
+            startDate: cal.date(byAdding: .year, value: -4, to: today) ?? today,
+            notes: "Advanced. Drilling competition-specific scenarios.",
+            defaultLessonRate: 95
+        )
+        context.insert(jordan)
+        context.insert(Payment(date: day(-30), amount: 475, method: .bankTransfer, lessonsCovered: 5, note: "5-lesson package", client: jordan))
+        context.insert(Lesson(date: day(-25), status: .completed, location: "Main mat", techniques: "Berimbolo, leg lock entries", rate: 95, client: jordan))
+        context.insert(Lesson(date: day(-12), status: .completed, location: "Main mat", techniques: "Pressure passing", rate: 95, client: jordan))
+        context.insert(Lesson(date: day(-3), status: .noShow, location: "Main mat", notes: "Did not show — follow up.", rate: 95, client: jordan))
+        context.insert(Lesson(date: day(3, hour: 18), status: .scheduled, location: "Main mat", techniques: "Comp simulation rounds", rate: 95, client: jordan))
+
+        try? context.save()
+    }
+
+    /// Seeds sample data only if the store has no clients yet.
+    @MainActor
+    static func seedIfEmpty(_ context: ModelContext) {
+        let descriptor = FetchDescriptor<Client>()
+        let count = (try? context.fetchCount(descriptor)) ?? 0
+        guard count == 0 else { return }
+        populate(context)
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Clients/ClientDetailView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Clients/ClientDetailView.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+import SwiftData
+
+struct ClientDetailView: View {
+    @Bindable var client: Client
+    @Environment(\.modelContext) private var context
+
+    @State private var showingEdit = false
+    @State private var showingAddLesson = false
+    @State private var showingAddPayment = false
+
+    private var recentLessons: [Lesson] {
+        client.lessonsList.sorted { $0.date > $1.date }
+    }
+
+    var body: some View {
+        List {
+            header
+
+            statsSection
+
+            if !client.upcomingLessons.isEmpty {
+                Section("Upcoming") {
+                    ForEach(client.upcomingLessons) { lesson in
+                        NavigationLink {
+                            LessonFormView(lesson: lesson)
+                        } label: {
+                            LessonRow(lesson: lesson, showClient: false)
+                        }
+                    }
+                }
+            }
+
+            Section {
+                if recentLessons.isEmpty {
+                    Text("No lessons logged yet.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(recentLessons) { lesson in
+                        NavigationLink {
+                            LessonFormView(lesson: lesson)
+                        } label: {
+                            LessonRow(lesson: lesson, showClient: false)
+                        }
+                    }
+                    .onDelete(perform: deleteLessons)
+                }
+            } header: {
+                HStack {
+                    Text("Lesson Log")
+                    Spacer()
+                    Button {
+                        showingAddLesson = true
+                    } label: {
+                        Label("Add", systemImage: "plus")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption)
+                    }
+                }
+            }
+
+            paymentsSection
+
+            if !client.notes.isEmpty {
+                Section("Notes") {
+                    Text(client.notes)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(client.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Edit") { showingEdit = true }
+            }
+        }
+        .sheet(isPresented: $showingEdit) {
+            ClientFormView(client: client)
+        }
+        .sheet(isPresented: $showingAddLesson) {
+            LessonFormView(presetClient: client)
+        }
+        .sheet(isPresented: $showingAddPayment) {
+            PaymentFormView(presetClient: client)
+        }
+    }
+
+    // MARK: Sections
+
+    private var header: some View {
+        Section {
+            HStack(spacing: 16) {
+                ClientAvatar(client: client, size: 64)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(client.displayName)
+                        .font(.title3.bold())
+                    BeltBadge(belt: client.belt, stripes: client.stripes)
+                    Text("Training since \(client.startDate.formatted(.dateTime.month(.abbreviated).year()))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(.vertical, 4)
+
+            if !client.email.isEmpty || !client.phone.isEmpty {
+                HStack(spacing: 24) {
+                    if let url = URL(string: "tel:\(client.phone)"), !client.phone.isEmpty {
+                        Link(destination: url) {
+                            Label("Call", systemImage: "phone")
+                        }
+                    }
+                    if let url = URL(string: "mailto:\(client.email)"), !client.email.isEmpty {
+                        Link(destination: url) {
+                            Label("Email", systemImage: "envelope")
+                        }
+                    }
+                }
+                .font(.subheadline)
+            }
+        }
+    }
+
+    private var statsSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                StatTile(title: "Completed", value: "\(client.completedLessons.count)", systemImage: "checkmark.circle", tint: .green)
+                StatTile(title: "Prepaid left", value: "\(client.lessonsRemaining)", systemImage: "ticket", tint: client.lessonsRemaining < 0 ? .red : .blue)
+                StatTile(title: "Balance", value: Format.money(client.outstandingBalance), systemImage: "dollarsign.circle", tint: client.outstandingBalance > 0 ? .red : .green)
+            }
+            .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+            .listRowBackground(Color.clear)
+        }
+    }
+
+    private var paymentsSection: some View {
+        Section {
+            let payments = client.paymentsList.sorted { $0.date > $1.date }
+            if payments.isEmpty {
+                Text("No payments recorded.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(payments) { payment in
+                    PaymentRow(payment: payment, showClient: false)
+                }
+                .onDelete { offsets in
+                    for index in offsets { context.delete(payments[index]) }
+                }
+            }
+        } header: {
+            HStack {
+                Text("Payments")
+                Spacer()
+                Button {
+                    showingAddPayment = true
+                } label: {
+                    Label("Add", systemImage: "plus")
+                        .labelStyle(.titleAndIcon)
+                        .font(.caption)
+                }
+            }
+        }
+    }
+
+    private func deleteLessons(at offsets: IndexSet) {
+        for index in offsets { context.delete(recentLessons[index]) }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PreviewClientDetail()
+    }
+    .modelContainer(AppModelContainer.makePreview())
+}
+
+/// Helper that grabs the first sample client for the preview.
+private struct PreviewClientDetail: View {
+    @Query(sort: \Client.name) private var clients: [Client]
+    var body: some View {
+        if let client = clients.first {
+            ClientDetailView(client: client)
+        } else {
+            Text("No sample client")
+        }
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Clients/ClientFormView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Clients/ClientFormView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import SwiftData
+
+/// Add or edit a client. Pass an existing client to edit, or omit to create.
+struct ClientFormView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+
+    /// The client being edited, or `nil` when creating a new one.
+    var client: Client?
+
+    @State private var name = ""
+    @State private var belt: BeltRank = .white
+    @State private var stripes = 0
+    @State private var email = ""
+    @State private var phone = ""
+    @State private var startDate = Date.now
+    @State private var notes = ""
+    @State private var isActive = true
+    @State private var defaultLessonRate = 0.0
+
+    private var isEditing: Bool { client != nil }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Profile") {
+                    TextField("Full name", text: $name)
+                        .textInputAutocapitalization(.words)
+                    Picker("Belt", selection: $belt) {
+                        ForEach(BeltRank.allCases) { Text($0.rawValue).tag($0) }
+                    }
+                    Stepper("Stripes: \(stripes)", value: $stripes, in: 0...4)
+                    DatePicker("Training since", selection: $startDate, displayedComponents: .date)
+                    Toggle("Active client", isOn: $isActive)
+                }
+
+                Section("Contact") {
+                    TextField("Email", text: $email)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.emailAddress)
+                        .autocorrectionDisabled()
+                    TextField("Phone", text: $phone)
+                        .keyboardType(.phonePad)
+                }
+
+                Section("Billing") {
+                    HStack {
+                        Text("Default lesson rate")
+                        Spacer()
+                        TextField("0", value: $defaultLessonRate, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                            .multilineTextAlignment(.trailing)
+                            .keyboardType(.decimalPad)
+                    }
+                }
+
+                Section("Notes") {
+                    TextField("Goals, injuries, preferences…", text: $notes, axis: .vertical)
+                        .lineLimit(3...8)
+                }
+            }
+            .navigationTitle(isEditing ? "Edit Client" : "New Client")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save", action: save)
+                        .disabled(name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+            .onAppear(perform: loadIfEditing)
+        }
+    }
+
+    private func loadIfEditing() {
+        guard let client else { return }
+        name = client.name
+        belt = client.belt
+        stripes = client.stripes
+        email = client.email
+        phone = client.phone
+        startDate = client.startDate
+        notes = client.notes
+        isActive = client.isActive
+        defaultLessonRate = client.defaultLessonRate
+    }
+
+    private func save() {
+        let target: Client
+        if let client {
+            target = client
+        } else {
+            target = Client()
+            context.insert(target)
+        }
+        target.name = name.trimmingCharacters(in: .whitespaces)
+        target.belt = belt
+        target.stripes = stripes
+        target.email = email
+        target.phone = phone
+        target.startDate = startDate
+        target.notes = notes
+        target.isActive = isActive
+        target.defaultLessonRate = defaultLessonRate
+        dismiss()
+    }
+}
+
+#Preview {
+    ClientFormView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Clients/ClientsListView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Clients/ClientsListView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import SwiftData
+
+struct ClientsListView: View {
+    @Environment(\.modelContext) private var context
+    @Query(sort: \Client.name) private var clients: [Client]
+    @State private var searchText = ""
+    @State private var showingAdd = false
+
+    private var filtered: [Client] {
+        guard !searchText.isEmpty else { return clients }
+        return clients.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private var activeClients: [Client] { filtered.filter(\.isActive) }
+    private var inactiveClients: [Client] { filtered.filter { !$0.isActive } }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if clients.isEmpty {
+                    ContentUnavailableView {
+                        Label("No clients yet", systemImage: "person.2")
+                    } description: {
+                        Text("Add your first private-lesson student to get started.")
+                    } actions: {
+                        Button("Add Client") { showingAdd = true }
+                            .buttonStyle(.borderedProminent)
+                    }
+                } else {
+                    List {
+                        Section(activeClients.isEmpty ? "" : "Active") {
+                            ForEach(activeClients) { client in
+                                clientRow(client)
+                            }
+                        }
+                        if !inactiveClients.isEmpty {
+                            Section("Inactive") {
+                                ForEach(inactiveClients) { client in
+                                    clientRow(client)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Clients")
+            .searchable(text: $searchText, prompt: "Search clients")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button { showingAdd = true } label: {
+                        Label("Add Client", systemImage: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                ClientFormView()
+            }
+        }
+    }
+
+    private func clientRow(_ client: Client) -> some View {
+        NavigationLink {
+            ClientDetailView(client: client)
+        } label: {
+            HStack(spacing: 12) {
+                ClientAvatar(client: client)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(client.displayName)
+                        .font(.headline)
+                    BeltBadge(belt: client.belt, stripes: client.stripes)
+                }
+                Spacer()
+                if let next = client.nextLesson {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text("Next")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(Format.relativeDay(next.date))
+                            .font(.caption.weight(.medium))
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                context.delete(client)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+}
+
+#Preview {
+    ClientsListView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Components/BeltBadge.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Components/BeltBadge.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// A small belt-rank pill with stripe markers, e.g. "Blue •• ".
+struct BeltBadge: View {
+    let belt: BeltRank
+    var stripes: Int = 0
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(belt.rawValue)
+                .font(.caption.weight(.semibold))
+            if stripes > 0 {
+                HStack(spacing: 2) {
+                    ForEach(0..<min(stripes, 4), id: \.self) { _ in
+                        Circle()
+                            .fill(belt.textColor)
+                            .frame(width: 4, height: 4)
+                    }
+                }
+            }
+        }
+        .foregroundStyle(belt.textColor)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(belt.color, in: Capsule())
+        .overlay(
+            Capsule().strokeBorder(Color.primary.opacity(belt == .white ? 0.2 : 0), lineWidth: 1)
+        )
+    }
+}
+
+/// Circular avatar showing a client's initials, tinted by belt color.
+struct ClientAvatar: View {
+    let client: Client
+    var size: CGFloat = 44
+
+    var body: some View {
+        Circle()
+            .fill(client.belt.color.gradient)
+            .frame(width: size, height: size)
+            .overlay(
+                Text(client.initials)
+                    .font(.system(size: size * 0.4, weight: .semibold))
+                    .foregroundStyle(client.belt.textColor)
+            )
+            .overlay(
+                Circle().strokeBorder(Color.primary.opacity(client.belt == .white ? 0.15 : 0), lineWidth: 1)
+            )
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        BeltBadge(belt: .white, stripes: 3)
+        BeltBadge(belt: .blue, stripes: 2)
+        BeltBadge(belt: .purple)
+        BeltBadge(belt: .brown, stripes: 1)
+        BeltBadge(belt: .black)
+    }
+    .padding()
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Components/StatusBadge.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Components/StatusBadge.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// A compact lesson-status pill (Scheduled / Completed / Cancelled / No-show).
+struct StatusBadge: View {
+    let status: LessonStatus
+
+    var body: some View {
+        Label(status.rawValue, systemImage: status.systemImage)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(status.tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(status.tint.opacity(0.12), in: Capsule())
+    }
+}
+
+/// A small labeled statistic used on dashboards and detail headers.
+struct StatTile: View {
+    let title: String
+    let value: String
+    var systemImage: String? = nil
+    var tint: Color = .accentColor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundStyle(tint)
+            }
+            Text(value)
+                .font(.title2.weight(.bold))
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color(.secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 14))
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Dashboard/DashboardView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Dashboard/DashboardView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import SwiftData
+
+struct DashboardView: View {
+    @Query(sort: \Lesson.date) private var lessons: [Lesson]
+    @Query private var clients: [Client]
+    @Query private var payments: [Payment]
+
+    @State private var showingAddLesson = false
+
+    private let cal = Calendar.current
+
+    private var todaysLessons: [Lesson] {
+        lessons.filter { cal.isDateInToday($0.date) }.sorted { $0.date < $1.date }
+    }
+
+    private var weekCount: Int {
+        lessons.filter {
+            cal.isDate($0.date, equalTo: .now, toGranularity: .weekOfYear) && $0.date >= cal.startOfDay(for: .now)
+        }.count
+    }
+
+    private var activeClientCount: Int {
+        clients.filter(\.isActive).count
+    }
+
+    private var monthRevenue: Double {
+        payments
+            .filter { cal.isDate($0.date, equalTo: .now, toGranularity: .month) }
+            .reduce(0) { $0 + $1.amount }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                        StatTile(title: "Today", value: "\(todaysLessons.count)", systemImage: "calendar.day.timeline.left", tint: .blue)
+                        StatTile(title: "This week", value: "\(weekCount)", systemImage: "calendar", tint: .indigo)
+                        StatTile(title: "Active clients", value: "\(activeClientCount)", systemImage: "person.2", tint: .purple)
+                        StatTile(title: "Revenue (mo.)", value: Format.money(monthRevenue), systemImage: "dollarsign.circle", tint: .green)
+                    }
+                    .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                    .listRowBackground(Color.clear)
+                }
+
+                Section("Today's Lessons") {
+                    if todaysLessons.isEmpty {
+                        HStack {
+                            Image(systemName: "checkmark.circle")
+                                .foregroundStyle(.green)
+                            Text("No lessons scheduled today.")
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        ForEach(todaysLessons) { lesson in
+                            NavigationLink {
+                                LessonFormView(lesson: lesson)
+                            } label: {
+                                LessonRow(lesson: lesson)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle(Date.now.formatted(.dateTime.weekday(.wide).month().day()))
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button { showingAddLesson = true } label: {
+                        Label("Schedule Lesson", systemImage: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAddLesson) {
+                LessonFormView()
+            }
+        }
+    }
+}
+
+#Preview {
+    DashboardView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Payments/PaymentFormView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Payments/PaymentFormView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import SwiftData
+
+/// Record or edit a payment. Provide `payment` to edit, or `presetClient`
+/// to pre-select the client when adding from a client's detail screen.
+struct PaymentFormView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: \Client.name) private var clients: [Client]
+
+    var payment: Payment?
+    var presetClient: Client?
+
+    @State private var client: Client?
+    @State private var date = Date.now
+    @State private var amount = 0.0
+    @State private var method: PaymentMethod = .cash
+    @State private var lessonsCovered = 1
+    @State private var note = ""
+
+    private var isEditing: Bool { payment != nil }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Client") {
+                    Picker("Client", selection: $client) {
+                        Text("Select…").tag(Client?.none)
+                        ForEach(clients) { c in
+                            Text(c.displayName).tag(Client?.some(c))
+                        }
+                    }
+                }
+
+                Section("Payment") {
+                    HStack {
+                        Text("Amount")
+                        Spacer()
+                        TextField("0", value: $amount, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                            .multilineTextAlignment(.trailing)
+                            .keyboardType(.decimalPad)
+                    }
+                    DatePicker("Date", selection: $date, displayedComponents: .date)
+                    Picker("Method", selection: $method) {
+                        ForEach(PaymentMethod.allCases) { Label($0.rawValue, systemImage: $0.systemImage).tag($0) }
+                    }
+                    Stepper("Lessons covered: \(lessonsCovered)", value: $lessonsCovered, in: 0...100)
+                }
+
+                Section("Note") {
+                    TextField("e.g. 10-lesson package", text: $note, axis: .vertical)
+                        .lineLimit(1...4)
+                }
+            }
+            .navigationTitle(isEditing ? "Edit Payment" : "Record Payment")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save", action: save)
+                        .disabled(client == nil || amount <= 0)
+                }
+            }
+            .onAppear(perform: load)
+        }
+    }
+
+    private func load() {
+        if let payment {
+            client = payment.client
+            date = payment.date
+            amount = payment.amount
+            method = payment.method
+            lessonsCovered = payment.lessonsCovered
+            note = payment.note
+        } else if let presetClient {
+            client = presetClient
+        }
+    }
+
+    private func save() {
+        let target: Payment
+        if let payment {
+            target = payment
+        } else {
+            target = Payment()
+            context.insert(target)
+        }
+        target.client = client
+        target.date = date
+        target.amount = amount
+        target.method = method
+        target.lessonsCovered = lessonsCovered
+        target.note = note
+        dismiss()
+    }
+}
+
+#Preview {
+    PaymentFormView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Payments/PaymentRow.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Payments/PaymentRow.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct PaymentRow: View {
+    let payment: Payment
+    var showClient: Bool = true
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: payment.method.systemImage)
+                .font(.title3)
+                .foregroundStyle(.green)
+                .frame(width: 32)
+
+            VStack(alignment: .leading, spacing: 3) {
+                if showClient {
+                    Text(payment.client?.displayName ?? "—")
+                        .font(.headline)
+                }
+                HStack(spacing: 6) {
+                    Text(payment.date.formatted(.dateTime.month(.abbreviated).day().year()))
+                    if payment.lessonsCovered > 0 {
+                        Text("· \(payment.lessonsCovered) lesson\(payment.lessonsCovered == 1 ? "" : "s")")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                if !payment.note.isEmpty {
+                    Text(payment.note)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+            Text(Format.money(payment.amount))
+                .font(.headline.monospacedDigit())
+                .foregroundStyle(.green)
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Payments/PaymentsView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Payments/PaymentsView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import SwiftData
+
+struct PaymentsView: View {
+    @Environment(\.modelContext) private var context
+    @Query(sort: \Payment.date, order: .reverse) private var payments: [Payment]
+    @State private var showingAdd = false
+
+    private var thisMonthTotal: Double {
+        let cal = Calendar.current
+        return payments
+            .filter { cal.isDate($0.date, equalTo: .now, toGranularity: .month) }
+            .reduce(0) { $0 + $1.amount }
+    }
+
+    private var allTimeTotal: Double {
+        payments.reduce(0) { $0 + $1.amount }
+    }
+
+    /// Payments grouped by "Month Year" header.
+    private var grouped: [(label: String, key: Date, payments: [Payment])] {
+        let cal = Calendar.current
+        let groups = Dictionary(grouping: payments) { payment -> Date in
+            let comps = cal.dateComponents([.year, .month], from: payment.date)
+            return cal.date(from: comps) ?? payment.date
+        }
+        return groups.keys.sorted(by: >).map { key in
+            (key.formatted(.dateTime.month(.wide).year()), key, groups[key]!.sorted { $0.date > $1.date })
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if payments.isEmpty {
+                    ContentUnavailableView {
+                        Label("No payments yet", systemImage: "creditcard")
+                    } description: {
+                        Text("Record a payment with the + button to start tracking revenue.")
+                    } actions: {
+                        Button("Record Payment") { showingAdd = true }
+                            .buttonStyle(.borderedProminent)
+                    }
+                } else {
+                    List {
+                        Section {
+                            HStack(spacing: 12) {
+                                StatTile(title: "This month", value: Format.money(thisMonthTotal), systemImage: "calendar", tint: .green)
+                                StatTile(title: "All time", value: Format.money(allTimeTotal), systemImage: "sum", tint: .blue)
+                            }
+                            .listRowInsets(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                            .listRowBackground(Color.clear)
+                        }
+
+                        ForEach(grouped, id: \.key) { group in
+                            Section(group.label) {
+                                ForEach(group.payments) { payment in
+                                    PaymentRow(payment: payment)
+                                }
+                                .onDelete { offsets in
+                                    for index in offsets { context.delete(group.payments[index]) }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Payments")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button { showingAdd = true } label: {
+                        Label("Record Payment", systemImage: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                PaymentFormView()
+            }
+        }
+    }
+}
+
+#Preview {
+    PaymentsView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/RootTabView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/RootTabView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import SwiftData
+
+struct RootTabView: View {
+    @Environment(\.modelContext) private var context
+
+    var body: some View {
+        TabView {
+            DashboardView()
+                .tabItem { Label("Today", systemImage: "sun.max") }
+
+            ClientsListView()
+                .tabItem { Label("Clients", systemImage: "person.2") }
+
+            ScheduleView()
+                .tabItem { Label("Schedule", systemImage: "calendar") }
+
+            PaymentsView()
+                .tabItem { Label("Payments", systemImage: "creditcard") }
+        }
+        .task {
+            // Seed sample data on the very first launch (no-op once data exists).
+            SampleData.seedIfEmpty(context)
+        }
+    }
+}
+
+#Preview {
+    RootTabView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Schedule/LessonFormView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Schedule/LessonFormView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import SwiftData
+
+/// Add or edit a lesson. Provide `lesson` to edit, or `presetClient` to
+/// pre-select a client when scheduling from a client's detail screen.
+struct LessonFormView: View {
+    @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: \Client.name) private var clients: [Client]
+
+    var lesson: Lesson?
+    var presetClient: Client?
+
+    @State private var client: Client?
+    @State private var date = Date.now
+    @State private var durationMinutes = 60
+    @State private var status: LessonStatus = .scheduled
+    @State private var location = ""
+    @State private var techniques = ""
+    @State private var notes = ""
+    @State private var rate = 0.0
+
+    private var isEditing: Bool { lesson != nil }
+
+    private let durationOptions = [30, 45, 60, 75, 90, 120]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Client") {
+                    Picker("Client", selection: $client) {
+                        Text("Select…").tag(Client?.none)
+                        ForEach(clients) { c in
+                            Text(c.displayName).tag(Client?.some(c))
+                        }
+                    }
+                }
+
+                Section("When") {
+                    DatePicker("Date & time", selection: $date)
+                    Picker("Duration", selection: $durationMinutes) {
+                        ForEach(durationOptions, id: \.self) { Text(Format.duration($0)).tag($0) }
+                    }
+                    Picker("Status", selection: $status) {
+                        ForEach(LessonStatus.allCases) { Label($0.rawValue, systemImage: $0.systemImage).tag($0) }
+                    }
+                }
+
+                Section("Details") {
+                    TextField("Location (e.g. Main mat)", text: $location)
+                    TextField("Techniques (comma separated)", text: $techniques, axis: .vertical)
+                        .lineLimit(2...6)
+                    HStack {
+                        Text("Rate")
+                        Spacer()
+                        TextField("0", value: $rate, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                            .multilineTextAlignment(.trailing)
+                            .keyboardType(.decimalPad)
+                    }
+                }
+
+                Section("Notes") {
+                    TextField("How did it go?", text: $notes, axis: .vertical)
+                        .lineLimit(3...8)
+                }
+            }
+            .navigationTitle(isEditing ? "Edit Lesson" : "New Lesson")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save", action: save)
+                        .disabled(client == nil)
+                }
+            }
+            .onAppear(perform: load)
+            .onChange(of: client) { _, newValue in
+                // Default the rate to the client's standard rate when unset.
+                if rate == 0, let r = newValue?.defaultLessonRate { rate = r }
+            }
+        }
+    }
+
+    private func load() {
+        if let lesson {
+            client = lesson.client
+            date = lesson.date
+            durationMinutes = lesson.durationMinutes
+            status = lesson.status
+            location = lesson.location
+            techniques = lesson.techniques
+            notes = lesson.notes
+            rate = lesson.rate
+        } else if let presetClient {
+            client = presetClient
+            rate = presetClient.defaultLessonRate
+            location = presetClient.lessonsList.first?.location ?? ""
+        }
+    }
+
+    private func save() {
+        let target: Lesson
+        if let lesson {
+            target = lesson
+        } else {
+            target = Lesson()
+            context.insert(target)
+        }
+        target.client = client
+        target.date = date
+        target.durationMinutes = durationMinutes
+        target.status = status
+        target.location = location
+        target.techniques = techniques
+        target.notes = notes
+        target.rate = rate
+        dismiss()
+    }
+}
+
+#Preview {
+    LessonFormView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Schedule/LessonRow.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Schedule/LessonRow.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// A single lesson row used in the schedule and on client detail screens.
+struct LessonRow: View {
+    let lesson: Lesson
+    var showClient: Bool = true
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(spacing: 2) {
+                Text(Format.time(lesson.date))
+                    .font(.callout.weight(.semibold))
+                    .monospacedDigit()
+                Text(Format.duration(lesson.durationMinutes))
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 64)
+
+            Rectangle()
+                .fill(lesson.status.tint)
+                .frame(width: 3)
+                .clipShape(Capsule())
+
+            VStack(alignment: .leading, spacing: 4) {
+                if showClient {
+                    Text(lesson.client?.displayName ?? "No client")
+                        .font(.headline)
+                }
+                if !lesson.techniqueTokens.isEmpty {
+                    Text(lesson.techniqueTokens.joined(separator: " • "))
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                } else if !lesson.location.isEmpty {
+                    Label(lesson.location, systemImage: "mappin.and.ellipse")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer(minLength: 4)
+            StatusBadge(status: lesson.status)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Schedule/ScheduleView.swift
+++ b/ios/JiuJitsuLessonTracker/JiuJitsuLessonTracker/Views/Schedule/ScheduleView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import SwiftData
+
+struct ScheduleView: View {
+    @Environment(\.modelContext) private var context
+    @Query(sort: \Lesson.date) private var lessons: [Lesson]
+    @State private var showingAdd = false
+    @State private var scope: Scope = .upcoming
+
+    enum Scope: String, CaseIterable, Identifiable {
+        case upcoming = "Upcoming"
+        case past = "Past"
+        var id: String { rawValue }
+    }
+
+    private var startOfToday: Date { Calendar.current.startOfDay(for: .now) }
+
+    private var visibleLessons: [Lesson] {
+        switch scope {
+        case .upcoming:
+            return lessons.filter { $0.date >= startOfToday }
+        case .past:
+            return lessons.filter { $0.date < startOfToday }
+        }
+    }
+
+    /// Lessons grouped by calendar day, preserving order.
+    private var grouped: [(day: Date, lessons: [Lesson])] {
+        let cal = Calendar.current
+        let groups = Dictionary(grouping: visibleLessons) { cal.startOfDay(for: $0.date) }
+        return groups.keys.sorted { scope == .upcoming ? $0 < $1 : $0 > $1 }
+            .map { ($0, groups[$0]!.sorted { $0.date < $1.date }) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if visibleLessons.isEmpty {
+                    ContentUnavailableView {
+                        Label(scope == .upcoming ? "Nothing scheduled" : "No past lessons",
+                              systemImage: "calendar")
+                    } description: {
+                        Text(scope == .upcoming
+                             ? "Schedule a lesson with the + button."
+                             : "Completed and past lessons will appear here.")
+                    }
+                } else {
+                    List {
+                        ForEach(grouped, id: \.day) { group in
+                            Section(dayHeader(group.day)) {
+                                ForEach(group.lessons) { lesson in
+                                    NavigationLink {
+                                        LessonFormView(lesson: lesson)
+                                    } label: {
+                                        LessonRow(lesson: lesson)
+                                    }
+                                    .swipeActions(edge: .leading) {
+                                        if lesson.status == .scheduled {
+                                            Button {
+                                                lesson.status = .completed
+                                            } label: {
+                                                Label("Done", systemImage: "checkmark")
+                                            }
+                                            .tint(.green)
+                                        }
+                                    }
+                                    .swipeActions(edge: .trailing) {
+                                        Button(role: .destructive) {
+                                            context.delete(lesson)
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Schedule")
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("Scope", selection: $scope) {
+                        ForEach(Scope.allCases) { Text($0.rawValue).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button { showingAdd = true } label: {
+                        Label("Schedule Lesson", systemImage: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAdd) {
+                LessonFormView()
+            }
+        }
+    }
+
+    private func dayHeader(_ day: Date) -> String {
+        let cal = Calendar.current
+        let full = day.formatted(.dateTime.weekday(.wide).month().day())
+        if cal.isDateInToday(day) || cal.isDateInTomorrow(day) || cal.isDateInYesterday(day) {
+            return "\(Format.relativeDay(day)) · \(full)"
+        }
+        return full
+    }
+}
+
+#Preview {
+    ScheduleView()
+        .modelContainer(AppModelContainer.makePreview())
+}

--- a/ios/JiuJitsuLessonTracker/README.md
+++ b/ios/JiuJitsuLessonTracker/README.md
@@ -1,0 +1,81 @@
+# Jiu-Jitsu Lesson Tracker
+
+A native iOS app for BJJ instructors to track private-lesson clients, log
+lessons, manage scheduling and attendance, and record payments — built with
+**SwiftUI** and **SwiftData**, with optional **iCloud (CloudKit)** sync.
+
+> Requires a Mac with **Xcode 16+** to build and run. Targets **iOS 17+**.
+
+## What it does
+
+| Tab | Purpose |
+| --- | --- |
+| **Today** | Dashboard: today's lessons + quick stats (week count, active clients, monthly revenue). |
+| **Clients** | Client profiles — name, belt rank & stripes, contact, training-since date, rate, notes. Per-client lesson log, payments, prepaid balance, and outstanding balance. |
+| **Schedule** | Upcoming vs. past lessons grouped by day. Swipe to mark a lesson **Done** or delete. Tracks attendance via status (Scheduled / Completed / Cancelled / No-show). |
+| **Payments** | Record payments with method and lessons-covered (package tracking). Monthly and all-time revenue totals. |
+
+The app **seeds sample clients, lessons, and payments on first launch** so you
+can explore it immediately. Delete them once you start entering real data.
+
+## Getting started
+
+1. On a Mac, open `JiuJitsuLessonTracker.xcodeproj` in Xcode 16 or later.
+2. Select an iOS Simulator (e.g. iPhone 15) as the run destination.
+3. Press **⌘R**. It builds and runs with on-device local storage — no signing
+   or accounts required.
+
+To run on your own iPhone, select the target → **Signing & Capabilities**,
+choose your Team, and set a unique **Bundle Identifier**
+(e.g. `com.yourname.JiuJitsuLessonTracker`).
+
+## Enabling iCloud sync (optional)
+
+Cloud sync keeps data backed up and in sync across your devices via your Apple
+ID. SwiftData mirrors the local store to your private CloudKit database — no
+extra networking code.
+
+1. Target → **Signing & Capabilities** → select your Team.
+2. **+ Capability → iCloud**, check **CloudKit**, and add a container
+   (e.g. `iCloud.com.yourname.JiuJitsuLessonTracker`).
+3. **+ Capability → Background Modes**, check **Remote notifications**.
+4. Open `Support/AppModelContainer.swift` and set `useCloudKit = true`.
+5. Rebuild on a device or a Simulator signed into an Apple ID.
+
+`JiuJitsuLessonTracker.entitlements` is included as a reference, but using the
+Signing & Capabilities UI is recommended — it registers the container under
+your account automatically.
+
+## Project structure
+
+```
+JiuJitsuLessonTracker/
+├── JiuJitsuLessonTrackerApp.swift   App entry + model container
+├── Models/                          SwiftData models (Client, Lesson, Payment) + enums
+├── Support/                         Container setup, sample data, formatters
+├── Views/
+│   ├── RootTabView.swift            Tab bar
+│   ├── Dashboard/                   "Today" overview
+│   ├── Clients/                     List, detail, add/edit form
+│   ├── Schedule/                    Schedule list, lesson row, add/edit form
+│   ├── Payments/                    Payments list, row, add/edit form
+│   └── Components/                  Belt badge, avatar, status badge, stat tile
+└── Assets.xcassets/                 App icon slot + accent color
+```
+
+### Data model
+
+- **Client** → has many **Lesson** and **Payment** (cascade delete).
+- **Lesson** carries a `status` that unifies scheduling and attendance.
+- **Payment** carries `lessonsCovered` to support prepaid packages, which feeds
+  each client's "prepaid left" and outstanding-balance figures.
+
+All model properties have defaults and relationships are optional, satisfying
+CloudKit's schema requirements.
+
+## Notes & next ideas
+
+- Add an **app icon** by dropping a 1024×1024 image into `Assets.xcassets/AppIcon`.
+- Possible future work: local notifications/reminders before lessons, a
+  techniques/skills curriculum checklist per belt, calendar export, and
+  charts of revenue and attendance over time.

--- a/static/lesson-tracker/README.md
+++ b/static/lesson-tracker/README.md
@@ -1,0 +1,39 @@
+# Jiu-Jitsu Lesson Tracker — Web Demo
+
+A self-contained web version of the lesson-tracker app, mirroring the SwiftUI
+iOS app (Today / Clients / Schedule / Payments). Built with plain HTML, CSS,
+and JavaScript — **no build step and no dependencies**.
+
+## How to view it
+
+- **Right now (local):** open `index.html` in any browser.
+- **On your live site:** because this folder lives in Gatsby's `static/`
+  directory, it's published automatically when the blog builds. After a deploy
+  it will be available at `/lesson-tracker/`.
+
+## What it does
+
+- **Today** — dashboard with today's lessons and quick stats (week count,
+  active clients, monthly revenue).
+- **Clients** — searchable client list; profiles with belt rank/stripes,
+  contact, rate, and notes; per-client lesson log, payments, and balances.
+- **Schedule** — upcoming vs. past lessons grouped by day; one-tap "mark
+  complete" for attendance.
+- **Payments** — record payments with method and package size; monthly and
+  all-time revenue totals.
+
+## Data & privacy
+
+All data is stored locally in your browser via `localStorage` — nothing is sent
+anywhere. The app seeds three sample clients on first load so you can explore
+it; edit or delete them and add your own. Clearing your browser data (or using
+a different browser/device) starts fresh. This demo is intentionally
+device-local; the native iOS app is the path to cross-device iCloud sync.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `index.html` | Page shell |
+| `styles.css` | All styling |
+| `app.js` | Data model, views, and interactions |

--- a/static/lesson-tracker/app.js
+++ b/static/lesson-tracker/app.js
@@ -1,0 +1,591 @@
+/* Jiu-Jitsu Lesson Tracker — web demo
+ * Vanilla JS, no dependencies. Data persists in the browser via localStorage.
+ * Mirrors the SwiftUI app: Today / Clients / Schedule / Payments.
+ */
+(function () {
+  "use strict";
+
+  // ---------- Constants ----------
+  const STORE_KEY = "jjlt.v1";
+  const BELTS = ["White", "Blue", "Purple", "Brown", "Black"];
+  const BELT_COLOR = { White: "#dcdce1", Blue: "#2b78e4", Purple: "#8944c4", Brown: "#7a4a2b", Black: "#1c1c1e" };
+  const BELT_TEXT = { White: "#1c1c1e", Blue: "#fff", Purple: "#fff", Brown: "#fff", Black: "#fff" };
+  const STATUSES = ["Scheduled", "Completed", "Cancelled", "No-show"];
+  const STATUS_COLOR = { Scheduled: "#2b78e4", Completed: "#2e9e54", Cancelled: "#e88b2a", "No-show": "#e0483d" };
+  const METHODS = ["Cash", "Card", "Bank transfer", "Venmo", "PayPal", "Other"];
+
+  // ---------- Helpers ----------
+  const fmtMoney = new Intl.NumberFormat(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 2 });
+  const money = (n) => fmtMoney.format(Number(n) || 0);
+  const uid = () => Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+  const esc = (s) =>
+    String(s == null ? "" : s).replace(/[&<>"']/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c])
+    );
+
+  function duration(min) {
+    min = Number(min) || 0;
+    if (min < 60) return min + " min";
+    const h = Math.floor(min / 60), m = min % 60;
+    return m === 0 ? h + " hr" : h + " hr " + m + " min";
+  }
+  function startOfDay(d) { const x = new Date(d); x.setHours(0, 0, 0, 0); return x; }
+  function dayDiff(a, b) { return Math.round((startOfDay(a) - startOfDay(b)) / 86400000); }
+  function relativeDay(d) {
+    const diff = dayDiff(d, new Date());
+    if (diff === 0) return "Today";
+    if (diff === 1) return "Tomorrow";
+    if (diff === -1) return "Yesterday";
+    return new Date(d).toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+  }
+  function fmtTime(d) { return new Date(d).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" }); }
+  function fmtDay(d) { return new Date(d).toLocaleDateString(undefined, { weekday: "long", month: "long", day: "numeric" }); }
+  function fmtMonthYear(d) { return new Date(d).toLocaleDateString(undefined, { month: "long", year: "numeric" }); }
+  function isToday(d) { return dayDiff(d, new Date()) === 0; }
+  function pad2(n) { return String(n).padStart(2, "0"); }
+  function toLocalInput(d) {
+    const x = new Date(d);
+    return x.getFullYear() + "-" + pad2(x.getMonth() + 1) + "-" + pad2(x.getDate()) + "T" + pad2(x.getHours()) + ":" + pad2(x.getMinutes());
+  }
+  function toDateInput(d) {
+    const x = new Date(d);
+    return x.getFullYear() + "-" + pad2(x.getMonth() + 1) + "-" + pad2(x.getDate());
+  }
+  function initials(name) {
+    const parts = String(name || "").trim().split(/\s+/).filter(Boolean);
+    const s = parts.slice(0, 2).map((p) => p[0]).join("").toUpperCase();
+    return s || "?";
+  }
+
+  // ---------- Data layer ----------
+  let db = load();
+  let view = { tab: "today", clientId: null, scheduleScope: "upcoming" };
+
+  function load() {
+    try {
+      const raw = localStorage.getItem(STORE_KEY);
+      if (raw) return JSON.parse(raw);
+    } catch (e) { /* ignore */ }
+    const seeded = seed();
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(seeded)); } catch (e) {}
+    return seeded;
+  }
+  function save() {
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(db)); } catch (e) {}
+  }
+
+  function seed() {
+    const today = startOfDay(new Date());
+    const day = (off, h = 17, m = 0) => {
+      const d = new Date(today); d.setDate(d.getDate() + off); d.setHours(h, m, 0, 0); return d.toISOString();
+    };
+    const monthsAgo = (n) => { const d = new Date(today); d.setMonth(d.getMonth() - n); return d.toISOString(); };
+    const yearsAgo = (n) => { const d = new Date(today); d.setFullYear(d.getFullYear() - n); return d.toISOString(); };
+
+    const alex = { id: uid(), name: "Alex Costa", belt: "Blue", stripes: 2, email: "alex.costa@example.com", phone: "555-0142", startDate: monthsAgo(14), notes: "Competing at the next local open. Working takedowns.", isActive: true, rate: 80 };
+    const maria = { id: uid(), name: "Maria Santos", belt: "White", stripes: 3, email: "maria.s@example.com", phone: "555-0188", startDate: monthsAgo(5), notes: "Focus on fundamentals and confidence. Prefers morning sessions.", isActive: true, rate: 70 };
+    const jordan = { id: uid(), name: "Jordan Lee", belt: "Purple", stripes: 0, email: "jordan.lee@example.com", phone: "555-0119", startDate: yearsAgo(4), notes: "Advanced. Drilling competition-specific scenarios.", isActive: true, rate: 95 };
+
+    const L = (clientId, date, status, location, techniques, rate, notes) =>
+      ({ id: uid(), clientId, date, durationMinutes: 60, status, location, techniques: techniques || "", notes: notes || "", rate });
+    const P = (clientId, date, amount, method, lessonsCovered, note) =>
+      ({ id: uid(), clientId, date, amount, method, lessonsCovered, note: note || "" });
+
+    return {
+      clients: [alex, maria, jordan],
+      lessons: [
+        L(alex.id, day(-18), "Completed", "Main mat", "Single leg, sprawl defense", 80),
+        L(alex.id, day(-11), "Completed", "Main mat", "Guard retention, hip escape", 80),
+        L(alex.id, day(-4), "Completed", "Main mat", "Knee cut pass, underhook", 80),
+        L(alex.id, day(2), "Scheduled", "Main mat", "Leg drag, back takes", 80),
+        L(alex.id, day(9), "Scheduled", "Main mat", "", 80),
+        L(maria.id, day(-7, 9), "Completed", "Studio B", "Mount escapes, bridge & roll", 70),
+        L(maria.id, day(1, 9), "Scheduled", "Studio B", "Closed guard basics", 70),
+        L(jordan.id, day(-25), "Completed", "Main mat", "Berimbolo, leg lock entries", 95),
+        L(jordan.id, day(-12), "Completed", "Main mat", "Pressure passing", 95),
+        L(jordan.id, day(-3), "No-show", "Main mat", "", 95, "Did not show — follow up."),
+        L(jordan.id, day(3, 18), "Scheduled", "Main mat", "Comp simulation rounds", 95),
+      ],
+      payments: [
+        P(alex.id, day(-20), 800, "Card", 10, "10-lesson package"),
+        P(maria.id, day(-7), 70, "Cash", 1, "Single lesson"),
+        P(jordan.id, day(-30), 475, "Bank transfer", 5, "5-lesson package"),
+      ],
+    };
+  }
+
+  // ---------- Derived ----------
+  const clientById = (id) => db.clients.find((c) => c.id === id);
+  const lessonsFor = (id) => db.lessons.filter((l) => l.clientId === id);
+  const paymentsFor = (id) => db.payments.filter((p) => p.clientId === id);
+  const completedFor = (id) => lessonsFor(id).filter((l) => l.status === "Completed");
+  function upcomingFor(id) {
+    const t = startOfDay(new Date());
+    return lessonsFor(id).filter((l) => l.status === "Scheduled" && new Date(l.date) >= t).sort((a, b) => new Date(a.date) - new Date(b.date));
+  }
+  const prepaidFor = (id) => paymentsFor(id).reduce((s, p) => s + (Number(p.lessonsCovered) || 0), 0);
+  const remainingFor = (id) => prepaidFor(id) - completedFor(id).length;
+  const totalPaidFor = (id) => paymentsFor(id).reduce((s, p) => s + (Number(p.amount) || 0), 0);
+  function balanceFor(id) {
+    const c = clientById(id);
+    const owedLessons = Math.max(0, -remainingFor(id));
+    return owedLessons * (Number(c.rate) || 0);
+  }
+
+  // ---------- Component HTML ----------
+  function beltBadge(belt, stripes) {
+    const bg = BELT_COLOR[belt] || "#ccc", fg = BELT_TEXT[belt] || "#fff";
+    let dots = "";
+    if (stripes > 0) {
+      dots = '<span class="stripes">' + Array.from({ length: Math.min(stripes, 4) }).map(() => '<span class="dot"></span>').join("") + "</span>";
+    }
+    return '<span class="belt" style="background:' + bg + ";color:" + fg + '">' + esc(belt) + dots + "</span>";
+  }
+  function avatar(client, lg) {
+    const bg = BELT_COLOR[client.belt] || "#ccc", fg = BELT_TEXT[client.belt] || "#fff";
+    return '<div class="avatar' + (lg ? " lg" : "") + '" style="background:' + bg + ";color:" + fg + '">' + esc(initials(client.name)) + "</div>";
+  }
+  function statusBadge(status) {
+    const col = STATUS_COLOR[status] || "#888";
+    return '<span class="status" style="color:' + col + '"><span class="bullet"></span>' + esc(status) + "</span>";
+  }
+  function tile(label, value, color, icon) {
+    return '<div class="tile"><div class="icon" style="color:' + (color || "var(--accent)") + '">' + icon + '</div>' +
+      '<div class="val">' + esc(value) + '</div><div class="lbl">' + esc(label) + "</div></div>";
+  }
+  function lessonRow(l, opts) {
+    opts = opts || {};
+    const c = clientById(l.clientId);
+    const col = STATUS_COLOR[l.status] || "#888";
+    const techs = String(l.techniques || "").split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
+    const sub = techs.length ? techs.join(" • ") : (l.location ? "📍 " + l.location : "");
+    const title = opts.showClient === false ? (sub || "Lesson") : (c ? c.name : "No client");
+    const meta = opts.showClient === false ? "" : sub;
+    const completeBtn = (opts.allowComplete && l.status === "Scheduled")
+      ? '<button class="btn small icon" data-action="complete" data-id="' + l.id + '" title="Mark completed">✓</button>' : "";
+    return '<li class="row" data-action="editLesson" data-id="' + l.id + '">' +
+      '<div class="lesson-time"><div class="t">' + fmtTime(l.date) + '</div><div class="d">' + duration(l.durationMinutes) + "</div></div>" +
+      '<div class="accent-bar" style="background:' + col + '"></div>' +
+      '<div class="grow"><div class="title">' + esc(title) + "</div>" +
+      (meta ? '<div class="meta">' + esc(meta) + "</div>" : "") + "</div>" +
+      '<div class="pill-row">' + statusBadge(l.status) + completeBtn + "</div></li>";
+  }
+  function paymentRow(p, showClient) {
+    const c = clientById(p.clientId);
+    const sub = new Date(p.date).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }) +
+      (p.lessonsCovered > 0 ? " · " + p.lessonsCovered + " lesson" + (p.lessonsCovered === 1 ? "" : "s") : "");
+    return '<li class="row" data-action="editPayment" data-id="' + p.id + '">' +
+      '<div class="grow"><div class="title">' + esc(showClient === false ? sub : (c ? c.name : "—")) + "</div>" +
+      (showClient === false ? (p.note ? '<div class="meta">' + esc(p.note) + "</div>" : "") :
+        '<div class="meta">' + esc(sub) + (p.note ? " · " + esc(p.note) : "") + "</div>") +
+      "</div>" +
+      '<div class="right" style="color:var(--green);font-weight:700">' + money(p.amount) + "</div></li>";
+  }
+  function emptyState(icon, title, msg, btn) {
+    return '<div class="empty"><div class="big">' + icon + '</div><h3>' + esc(title) + "</h3>" +
+      '<p class="muted">' + esc(msg) + "</p>" + (btn || "") + "</div>";
+  }
+  function group(items, keyFn) {
+    const map = new Map();
+    items.forEach((it) => { const k = keyFn(it); if (!map.has(k)) map.set(k, []); map.get(k).push(it); });
+    return map;
+  }
+
+  // ---------- Views ----------
+  function viewToday() {
+    const today = db.lessons.filter((l) => isToday(l.date)).sort((a, b) => new Date(a.date) - new Date(b.date));
+    const week = db.lessons.filter((l) => { const diff = dayDiff(l.date, new Date()); return diff >= 0 && diff < 7; }).length;
+    const active = db.clients.filter((c) => c.isActive).length;
+    const now = new Date();
+    const revenue = db.payments.filter((p) => { const d = new Date(p.date); return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear(); })
+      .reduce((s, p) => s + p.amount, 0);
+
+    let html = '<div class="content">';
+    html += '<div class="section"><div class="stats four">' +
+      tile("Today", today.length, "var(--blue)", "📅") +
+      tile("This week", week, "var(--indigo)", "🗓️") +
+      tile("Active clients", active, "var(--purple)", "🥋") +
+      tile("Revenue (mo.)", money(revenue), "var(--green)", "💵") +
+      "</div></div>";
+
+    html += '<div class="section"><div class="section-head"><h2>Today\'s Lessons</h2></div>';
+    if (today.length === 0) {
+      html += '<div class="card pad muted">✓ No lessons scheduled today.</div>';
+    } else {
+      html += '<ul class="list card">' + today.map((l) => lessonRow(l, { allowComplete: true })).join("") + "</ul>";
+    }
+    html += "</div></div>";
+    return html;
+  }
+
+  function viewClients() {
+    const q = (view.search || "").toLowerCase();
+    let clients = db.clients.slice().sort((a, b) => a.name.localeCompare(b.name));
+    if (q) clients = clients.filter((c) => c.name.toLowerCase().includes(q));
+    const active = clients.filter((c) => c.isActive);
+    const inactive = clients.filter((c) => !c.isActive);
+
+    let html = '<div class="content">';
+    html += '<div class="field" style="margin-bottom:14px"><input type="search" placeholder="Search clients" value="' + esc(view.search || "") + '" data-action="searchClients"></div>';
+
+    if (db.clients.length === 0) {
+      html += emptyState("🥋", "No clients yet", "Add your first private-lesson student to get started.",
+        '<button class="btn primary" data-action="addClient">Add Client</button>');
+      return html + "</div>";
+    }
+    const section = (label, list) => {
+      if (!list.length) return "";
+      return '<div class="section"><div class="section-head"><h2>' + label + "</h2></div>" +
+        '<ul class="list card">' + list.map(clientRowHtml).join("") + "</ul></div>";
+    };
+    html += section("Active", active) + section("Inactive", inactive);
+    return html + "</div>";
+  }
+
+  function clientRowHtml(c) {
+    const next = upcomingFor(c.id)[0];
+    return '<li class="row" data-action="openClient" data-id="' + c.id + '">' +
+      avatar(c) +
+      '<div class="grow"><div class="title">' + esc(c.name) + "</div>" +
+      '<div style="margin-top:4px">' + beltBadge(c.belt, c.stripes) + "</div></div>" +
+      (next ? '<div class="trail"><div class="muted" style="font-size:11px">Next</div>' + esc(relativeDay(next.date)) + "</div>" : "") +
+      "</li>";
+  }
+
+  function viewClientDetail() {
+    const c = clientById(view.clientId);
+    if (!c) { view.tab = "clients"; return viewClients(); }
+    const lessons = lessonsFor(c.id).sort((a, b) => new Date(b.date) - new Date(a.date));
+    const upcoming = upcomingFor(c.id);
+    const payments = paymentsFor(c.id).sort((a, b) => new Date(b.date) - new Date(a.date));
+    const remaining = remainingFor(c.id);
+    const balance = balanceFor(c.id);
+
+    let html = '<div class="content">';
+
+    // header
+    html += '<div class="card pad section">' +
+      '<div class="detail-head">' + avatar(c, true) +
+      '<div><div class="name">' + esc(c.name) + "</div>" +
+      '<div style="margin-top:6px">' + beltBadge(c.belt, c.stripes) + "</div>" +
+      '<div class="since">Training since ' + new Date(c.startDate).toLocaleDateString(undefined, { month: "short", year: "numeric" }) + "</div></div></div>";
+    const links = [];
+    if (c.phone) links.push('<a href="tel:' + esc(c.phone) + '">📞 Call</a>');
+    if (c.email) links.push('<a href="mailto:' + esc(c.email) + '">✉️ Email</a>');
+    if (links.length) html += '<div class="contact-links">' + links.join("") + "</div>";
+    html += "</div>";
+
+    // stats
+    html += '<div class="section"><div class="stats three">' +
+      tile("Completed", completedFor(c.id).length, "var(--green)", "✅") +
+      tile("Prepaid left", remaining, remaining < 0 ? "var(--red)" : "var(--blue)", "🎟️") +
+      tile("Balance", money(balance), balance > 0 ? "var(--red)" : "var(--green)", "💲") +
+      "</div></div>";
+
+    if (upcoming.length) {
+      html += '<div class="section"><div class="section-head"><h2>Upcoming</h2></div>' +
+        '<ul class="list card">' + upcoming.map((l) => lessonRow(l, { showClient: false })).join("") + "</ul></div>";
+    }
+
+    // lesson log
+    html += '<div class="section"><div class="section-head"><h2>Lesson Log</h2>' +
+      '<button class="btn small" data-action="addLesson" data-id="' + c.id + '">+ Add</button></div>';
+    html += lessons.length
+      ? '<ul class="list card">' + lessons.map((l) => lessonRow(l, { showClient: false })).join("") + "</ul>"
+      : '<div class="card pad muted">No lessons logged yet.</div>';
+    html += "</div>";
+
+    // payments
+    html += '<div class="section"><div class="section-head"><h2>Payments</h2>' +
+      '<button class="btn small" data-action="addPayment" data-id="' + c.id + '">+ Add</button></div>';
+    html += payments.length
+      ? '<ul class="list card">' + payments.map((p) => paymentRow(p, false)).join("") + "</ul>"
+      : '<div class="card pad muted">No payments recorded.</div>';
+    html += "</div>";
+
+    if (c.notes) {
+      html += '<div class="section"><div class="section-head"><h2>Notes</h2></div>' +
+        '<div class="card pad notes-text">' + esc(c.notes) + "</div></div>";
+    }
+
+    return html + "</div>";
+  }
+
+  function viewSchedule() {
+    const t0 = startOfDay(new Date());
+    const scope = view.scheduleScope;
+    let lessons = db.lessons.filter((l) => scope === "upcoming" ? new Date(l.date) >= t0 : new Date(l.date) < t0);
+    lessons.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+    let html = '<div class="content">';
+    html += '<div class="section center"><div class="segment">' +
+      '<button class="' + (scope === "upcoming" ? "active" : "") + '" data-action="scope" data-id="upcoming">Upcoming</button>' +
+      '<button class="' + (scope === "past" ? "active" : "") + '" data-action="scope" data-id="past">Past</button>' +
+      "</div></div>";
+
+    if (!lessons.length) {
+      html += emptyState("📅", scope === "upcoming" ? "Nothing scheduled" : "No past lessons",
+        scope === "upcoming" ? "Use the + button to schedule a lesson." : "Completed and past lessons will appear here.", "");
+      return html + "</div>";
+    }
+
+    const grouped = group(lessons, (l) => startOfDay(l.date).getTime());
+    let keys = Array.from(grouped.keys());
+    keys.sort((a, b) => scope === "upcoming" ? a - b : b - a);
+    keys.forEach((k) => {
+      const dayLessons = grouped.get(k).sort((a, b) => new Date(a.date) - new Date(b.date));
+      const rel = relativeDay(k);
+      const full = fmtDay(k);
+      const header = (rel === "Today" || rel === "Tomorrow" || rel === "Yesterday") ? rel + " · " + full : full;
+      html += '<div class="section"><div class="section-head"><h2>' + esc(header) + "</h2></div>" +
+        '<ul class="list card">' + dayLessons.map((l) => lessonRow(l, { showClient: true, allowComplete: true })).join("") + "</ul></div>";
+    });
+    return html + "</div>";
+  }
+
+  function viewPayments() {
+    const now = new Date();
+    const payments = db.payments.slice().sort((a, b) => new Date(b.date) - new Date(a.date));
+    const monthTotal = payments.filter((p) => { const d = new Date(p.date); return d.getMonth() === now.getMonth() && d.getFullYear() === now.getFullYear(); }).reduce((s, p) => s + p.amount, 0);
+    const allTotal = payments.reduce((s, p) => s + p.amount, 0);
+
+    let html = '<div class="content">';
+    if (!payments.length) {
+      html += emptyState("💳", "No payments yet", "Record a payment with the + button to start tracking revenue.",
+        '<button class="btn primary" data-action="addPayment">Record Payment</button>');
+      return html + "</div>";
+    }
+    html += '<div class="section"><div class="stats">' +
+      tile("This month", money(monthTotal), "var(--green)", "📅") +
+      tile("All time", money(allTotal), "var(--blue)", "Σ") +
+      "</div></div>";
+
+    const grouped = group(payments, (p) => { const d = new Date(p.date); return d.getFullYear() + "-" + pad2(d.getMonth() + 1); });
+    const keys = Array.from(grouped.keys()).sort((a, b) => b.localeCompare(a));
+    keys.forEach((k) => {
+      const list = grouped.get(k);
+      html += '<div class="section"><div class="section-head"><h2>' + esc(fmtMonthYear(list[0].date)) + "</h2></div>" +
+        '<ul class="list card">' + list.map((p) => paymentRow(p, true)).join("") + "</ul></div>";
+    });
+    return html + "</div>";
+  }
+
+  // ---------- App bar ----------
+  function appbar() {
+    if (view.tab === "clientDetail") {
+      const c = clientById(view.clientId);
+      return '<div class="appbar"><button class="back" data-action="back">‹ Clients</button>' +
+        '<h1 style="font-size:18px;text-align:center">' + esc(c ? c.name : "Client") + "</h1>" +
+        '<button class="btn small" data-action="editClient" data-id="' + view.clientId + '">Edit</button></div>';
+    }
+    const titles = {
+      today: { t: fmtDay(new Date()), sub: "Today" },
+      clients: { t: "Clients" },
+      schedule: { t: "Schedule" },
+      payments: { t: "Payments" },
+    };
+    const cfg = titles[view.tab] || { t: "" };
+    let action = "";
+    if (view.tab === "clients") action = '<button class="btn icon primary" data-action="addClient">＋</button>';
+    if (view.tab === "schedule" || view.tab === "today") action = '<button class="btn icon primary" data-action="addLesson">＋</button>';
+    if (view.tab === "payments") action = '<button class="btn icon primary" data-action="addPayment">＋</button>';
+    return '<div class="appbar"><h1>' + esc(cfg.t) + (cfg.sub ? '<span class="sub">' + esc(cfg.sub) + "</span>" : "") + "</h1>" + action + "</div>";
+  }
+
+  function tabbar() {
+    const tabs = [
+      { id: "today", ic: "☀️", label: "Today" },
+      { id: "clients", ic: "👥", label: "Clients" },
+      { id: "schedule", ic: "📅", label: "Schedule" },
+      { id: "payments", ic: "💳", label: "Payments" },
+    ];
+    const activeTab = view.tab === "clientDetail" ? "clients" : view.tab;
+    return '<nav class="tabbar">' + tabs.map((t) =>
+      '<button class="tab ' + (activeTab === t.id ? "active" : "") + '" data-action="tab" data-id="' + t.id + '">' +
+      '<span class="ic">' + t.ic + "</span>" + t.label + "</button>").join("") + "</nav>";
+  }
+
+  // ---------- Render ----------
+  function render() {
+    let body;
+    switch (view.tab) {
+      case "today": body = viewToday(); break;
+      case "clients": body = viewClients(); break;
+      case "clientDetail": body = viewClientDetail(); break;
+      case "schedule": body = viewSchedule(); break;
+      case "payments": body = viewPayments(); break;
+      default: body = viewToday();
+    }
+    document.getElementById("app").innerHTML = appbar() + body + tabbar();
+  }
+
+  // ---------- Modals / forms ----------
+  function closeModal() {
+    const m = document.getElementById("modal-root");
+    if (m) m.innerHTML = "";
+  }
+  function modal(title, innerHtml, onSubmit, extraActions) {
+    const root = document.getElementById("modal-root");
+    root.innerHTML =
+      '<div class="modal-backdrop" id="backdrop"><div class="modal">' +
+      '<div class="modal-bar"><button class="btn ghost" data-close>Cancel</button>' +
+      "<h2>" + esc(title) + "</h2>" +
+      '<button class="btn ghost" form="modal-form" type="submit" style="color:var(--accent);font-weight:700">Save</button></div>' +
+      '<form id="modal-form">' + innerHtml +
+      (extraActions || "") + "</form></div></div>";
+    const form = document.getElementById("modal-form");
+    form.addEventListener("submit", function (e) { e.preventDefault(); onSubmit(new FormData(form)); });
+    root.querySelectorAll("[data-close]").forEach((b) => b.addEventListener("click", closeModal));
+    document.getElementById("backdrop").addEventListener("click", function (e) {
+      if (e.target.id === "backdrop") closeModal();
+    });
+  }
+
+  function field(label, name, value, type, attrs) {
+    return '<div class="field"><label>' + esc(label) + "</label>" +
+      '<input name="' + name + '" type="' + (type || "text") + '" value="' + esc(value == null ? "" : value) + '" ' + (attrs || "") + "></div>";
+  }
+  function selectField(label, name, options, selected) {
+    return '<div class="field"><label>' + esc(label) + "</label><select name=\"" + name + "\">" +
+      options.map((o) => '<option value="' + esc(o) + '"' + (o === selected ? " selected" : "") + ">" + esc(o) + "</option>").join("") +
+      "</select></div>";
+  }
+  function textareaField(label, name, value) {
+    return '<div class="field"><label>' + esc(label) + "</label><textarea name=\"" + name + "\">" + esc(value || "") + "</textarea></div>";
+  }
+  function deleteAction(action, id, label) {
+    return '<div class="field"><button type="button" class="btn ghost danger" style="width:100%" data-action="' + action + '" data-id="' + id + '">' + esc(label) + "</button></div>";
+  }
+
+  // Client form
+  function clientForm(existing) {
+    const c = existing || { name: "", belt: "White", stripes: 0, email: "", phone: "", startDate: new Date().toISOString(), notes: "", isActive: true, rate: 0 };
+    const inner =
+      field("Full name", "name", c.name, "text", 'autocapitalize="words" required') +
+      '<div class="field-row">' + selectField("Belt", "belt", BELTS, c.belt) +
+      field("Stripes", "stripes", c.stripes, "number", 'min="0" max="4"') + "</div>" +
+      field("Training since", "startDate", toDateInput(c.startDate), "date") +
+      '<div class="field toggle-row"><label style="margin:0">Active client</label><input type="checkbox" name="isActive" ' + (c.isActive ? "checked" : "") + ' style="width:auto"></div>' +
+      '<div class="field-row">' + field("Email", "email", c.email, "email") + field("Phone", "phone", c.phone, "tel") + "</div>" +
+      field("Default lesson rate", "rate", c.rate, "number", 'min="0" step="0.01"') +
+      textareaField("Notes (goals, injuries, preferences…)", "notes", c.notes);
+    modal(existing ? "Edit Client" : "New Client", inner, function (fd) {
+      const obj = {
+        name: (fd.get("name") || "").trim(), belt: fd.get("belt"), stripes: parseInt(fd.get("stripes")) || 0,
+        startDate: new Date(fd.get("startDate") || Date.now()).toISOString(), isActive: fd.get("isActive") === "on",
+        email: fd.get("email") || "", phone: fd.get("phone") || "", rate: parseFloat(fd.get("rate")) || 0, notes: fd.get("notes") || "",
+      };
+      if (!obj.name) return;
+      if (existing) { Object.assign(existing, obj); }
+      else { obj.id = uid(); db.clients.push(obj); }
+      save(); closeModal(); render();
+    }, existing ? deleteAction("deleteClient", existing.id, "Delete Client") : "");
+  }
+
+  // Lesson form
+  function lessonForm(existing, presetClientId) {
+    if (!db.clients.length) { alert("Add a client first."); return; }
+    const l = existing || { clientId: presetClientId || db.clients[0].id, date: new Date().toISOString(), durationMinutes: 60, status: "Scheduled", location: "", techniques: "", notes: "", rate: 0 };
+    const clientOpts = db.clients.map((c) => '<option value="' + c.id + '"' + (c.id === l.clientId ? " selected" : "") + ">" + esc(c.name) + "</option>").join("");
+    const inner =
+      '<div class="field"><label>Client</label><select name="clientId">' + clientOpts + "</select></div>" +
+      field("Date & time", "date", toLocalInput(l.date), "datetime-local") +
+      '<div class="field-row">' +
+      selectField("Duration", "durationMinutes", ["30", "45", "60", "75", "90", "120"], String(l.durationMinutes)) +
+      selectField("Status", "status", STATUSES, l.status) + "</div>" +
+      field("Location", "location", l.location, "text") +
+      textareaField("Techniques (comma separated)", "techniques", l.techniques) +
+      field("Rate", "rate", l.rate, "number", 'min="0" step="0.01"') +
+      textareaField("Notes", "notes", l.notes);
+    modal(existing ? "Edit Lesson" : "New Lesson", inner, function (fd) {
+      const obj = {
+        clientId: fd.get("clientId"), date: new Date(fd.get("date")).toISOString(),
+        durationMinutes: parseInt(fd.get("durationMinutes")) || 60, status: fd.get("status"),
+        location: fd.get("location") || "", techniques: fd.get("techniques") || "", notes: fd.get("notes") || "",
+        rate: parseFloat(fd.get("rate")) || 0,
+      };
+      if (existing) { Object.assign(existing, obj); }
+      else { obj.id = uid(); db.lessons.push(obj); }
+      save(); closeModal(); render();
+    }, existing ? deleteAction("deleteLesson", existing.id, "Delete Lesson") : "");
+  }
+
+  // Payment form
+  function paymentForm(existing, presetClientId) {
+    if (!db.clients.length) { alert("Add a client first."); return; }
+    const p = existing || { clientId: presetClientId || db.clients[0].id, date: new Date().toISOString(), amount: 0, method: "Cash", lessonsCovered: 1, note: "" };
+    const clientOpts = db.clients.map((c) => '<option value="' + c.id + '"' + (c.id === p.clientId ? " selected" : "") + ">" + esc(c.name) + "</option>").join("");
+    const inner =
+      '<div class="field"><label>Client</label><select name="clientId">' + clientOpts + "</select></div>" +
+      '<div class="field-row">' + field("Amount", "amount", p.amount, "number", 'min="0" step="0.01" required') +
+      field("Date", "date", toDateInput(p.date), "date") + "</div>" +
+      '<div class="field-row">' + selectField("Method", "method", METHODS, p.method) +
+      field("Lessons covered", "lessonsCovered", p.lessonsCovered, "number", 'min="0" max="100"') + "</div>" +
+      field("Note", "note", p.note, "text");
+    modal(existing ? "Edit Payment" : "Record Payment", inner, function (fd) {
+      const obj = {
+        clientId: fd.get("clientId"), date: new Date(fd.get("date")).toISOString(),
+        amount: parseFloat(fd.get("amount")) || 0, method: fd.get("method"),
+        lessonsCovered: parseInt(fd.get("lessonsCovered")) || 0, note: fd.get("note") || "",
+      };
+      if (obj.amount <= 0) return;
+      if (existing) { Object.assign(existing, obj); }
+      else { obj.id = uid(); db.payments.push(obj); }
+      save(); closeModal(); render();
+    }, existing ? deleteAction("deletePayment", existing.id, "Delete Payment") : "");
+  }
+
+  // ---------- Event handling ----------
+  document.addEventListener("click", function (e) {
+    const el = e.target.closest("[data-action]");
+    if (!el) return;
+    const action = el.getAttribute("data-action");
+    const id = el.getAttribute("data-id");
+
+    switch (action) {
+      case "tab": view.tab = id; view.clientId = null; window.scrollTo(0, 0); render(); break;
+      case "back": view.tab = "clients"; view.clientId = null; render(); break;
+      case "openClient": view.tab = "clientDetail"; view.clientId = id; window.scrollTo(0, 0); render(); break;
+      case "scope": view.scheduleScope = id; render(); break;
+      case "addClient": clientForm(null); break;
+      case "editClient": clientForm(clientById(id)); break;
+      case "addLesson": lessonForm(null, view.tab === "clientDetail" ? view.clientId : id); break;
+      case "editLesson": lessonForm(db.lessons.find((l) => l.id === id)); break;
+      case "addPayment": paymentForm(null, view.tab === "clientDetail" ? view.clientId : id); break;
+      case "editPayment": paymentForm(db.payments.find((p) => p.id === id)); break;
+      case "complete": {
+        const l = db.lessons.find((x) => x.id === id);
+        if (l) { l.status = "Completed"; save(); render(); }
+        break;
+      }
+      case "deleteClient":
+        if (confirm("Delete this client and all their lessons and payments?")) {
+          db.clients = db.clients.filter((c) => c.id !== id);
+          db.lessons = db.lessons.filter((l) => l.clientId !== id);
+          db.payments = db.payments.filter((p) => p.clientId !== id);
+          save(); closeModal(); view.tab = "clients"; view.clientId = null; render();
+        }
+        break;
+      case "deleteLesson":
+        db.lessons = db.lessons.filter((l) => l.id !== id); save(); closeModal(); render(); break;
+      case "deletePayment":
+        db.payments = db.payments.filter((p) => p.id !== id); save(); closeModal(); render(); break;
+    }
+  });
+
+  document.addEventListener("input", function (e) {
+    const el = e.target.closest("[data-action]");
+    if (!el) return;
+    if (el.getAttribute("data-action") === "searchClients") {
+      view.search = el.value;
+      // Re-render the view, then restore focus + caret to the search field.
+      const pos = el.selectionStart;
+      render();
+      const again = document.querySelector('[data-action="searchClients"]');
+      if (again) { again.focus(); try { again.setSelectionRange(pos, pos); } catch (x) {} }
+    }
+  });
+
+  // ---------- Boot ----------
+  render();
+})();

--- a/static/lesson-tracker/app.js
+++ b/static/lesson-tracker/app.js
@@ -8,10 +8,10 @@
   // ---------- Constants ----------
   const STORE_KEY = "jjlt.v1";
   const BELTS = ["White", "Blue", "Purple", "Brown", "Black"];
-  const BELT_COLOR = { White: "#dcdce1", Blue: "#2b78e4", Purple: "#8944c4", Brown: "#7a4a2b", Black: "#1c1c1e" };
-  const BELT_TEXT = { White: "#1c1c1e", Blue: "#fff", Purple: "#fff", Brown: "#fff", Black: "#fff" };
+  const BELT_COLOR = { White: "#e4e4e8", Blue: "#3a86e0", Purple: "#a05cd6", Brown: "#8a5a36", Black: "#2c2c31" };
+  const BELT_TEXT = { White: "#161618", Blue: "#fff", Purple: "#fff", Brown: "#fff", Black: "#fff" };
   const STATUSES = ["Scheduled", "Completed", "Cancelled", "No-show"];
-  const STATUS_COLOR = { Scheduled: "#2b78e4", Completed: "#2e9e54", Cancelled: "#e88b2a", "No-show": "#e0483d" };
+  const STATUS_COLOR = { Scheduled: "#4a90e2", Completed: "#34c76a", Cancelled: "#eb9a3c", "No-show": "#ef5a4f" };
   const METHODS = ["Cash", "Card", "Bank transfer", "Venmo", "PayPal", "Other"];
 
   // ---------- Helpers ----------
@@ -202,10 +202,10 @@
 
     let html = '<div class="content">';
     html += '<div class="section"><div class="stats four">' +
-      tile("Today", today.length, "var(--blue)", "📅") +
-      tile("This week", week, "var(--indigo)", "🗓️") +
-      tile("Active clients", active, "var(--purple)", "🥋") +
-      tile("Revenue (mo.)", money(revenue), "var(--green)", "💵") +
+      tile("Today", today.length, "var(--gold)", "📅") +
+      tile("This week", week, "var(--gold)", "🗓️") +
+      tile("Active clients", active, "var(--gold)", "🥋") +
+      tile("Revenue (mo.)", money(revenue), "var(--gold)", "💵") +
       "</div></div>";
 
     html += '<div class="section"><div class="section-head"><h2>Today\'s Lessons</h2></div>';
@@ -277,9 +277,9 @@
 
     // stats
     html += '<div class="section"><div class="stats three">' +
-      tile("Completed", completedFor(c.id).length, "var(--green)", "✅") +
-      tile("Prepaid left", remaining, remaining < 0 ? "var(--red)" : "var(--blue)", "🎟️") +
-      tile("Balance", money(balance), balance > 0 ? "var(--red)" : "var(--green)", "💲") +
+      tile("Completed", completedFor(c.id).length, "var(--gold)", "✅") +
+      tile("Prepaid left", remaining, remaining < 0 ? "var(--red)" : "var(--gold)", "🎟️") +
+      tile("Balance", money(balance), balance > 0 ? "var(--red)" : "var(--gold)", "💲") +
       "</div></div>";
 
     if (upcoming.length) {
@@ -356,8 +356,8 @@
       return html + "</div>";
     }
     html += '<div class="section"><div class="stats">' +
-      tile("This month", money(monthTotal), "var(--green)", "📅") +
-      tile("All time", money(allTotal), "var(--blue)", "Σ") +
+      tile("This month", money(monthTotal), "var(--gold)", "📅") +
+      tile("All time", money(allTotal), "var(--gold)", "Σ") +
       "</div></div>";
 
     const grouped = group(payments, (p) => { const d = new Date(p.date); return d.getFullYear() + "-" + pad2(d.getMonth() + 1); });

--- a/static/lesson-tracker/index.html
+++ b/static/lesson-tracker/index.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
-  <meta name="theme-color" content="#1a6b3c" />
+  <meta name="theme-color" content="#161618" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="BJJ Tracker" />
+  <meta name="color-scheme" content="dark" />
   <meta name="description" content="Track private jiu-jitsu lessons, clients, scheduling and payments." />
   <title>Jiu-Jitsu Lesson Tracker</title>
   <link rel="stylesheet" href="styles.css" />

--- a/static/lesson-tracker/index.html
+++ b/static/lesson-tracker/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
+  <meta name="theme-color" content="#1a6b3c" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="BJJ Tracker" />
+  <meta name="description" content="Track private jiu-jitsu lessons, clients, scheduling and payments." />
+  <title>Jiu-Jitsu Lesson Tracker</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <div id="modal-root"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/static/lesson-tracker/styles.css
+++ b/static/lesson-tracker/styles.css
@@ -1,20 +1,24 @@
 :root {
-  --bg: #f2f2f7;
-  --card: #ffffff;
-  --card-2: #f7f7fa;
-  --ink: #1c1c1e;
-  --ink-2: #6b6b70;
-  --line: #e4e4e9;
-  --accent: #1a6b3c;       /* mat green */
-  --accent-ink: #ffffff;
-  --green: #2e9e54;
-  --blue: #2b78e4;
-  --indigo: #5b5bd6;
-  --purple: #8944c4;
-  --red: #e0483d;
-  --orange: #e88b2a;
-  --radius: 16px;
-  --shadow: 0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+  --bg: #161618;          /* dark charcoal */
+  --bg-2: #1d1d20;
+  --card: #202024;        /* elevated surface */
+  --card-2: #2a2a30;      /* inputs / chips */
+  --ink: #f4f4f6;         /* near-white text */
+  --ink-2: #9a9aa3;       /* muted text */
+  --line: #313138;        /* hairline borders */
+  --gold: #d8b24c;        /* primary accent */
+  --gold-soft: #e6c97a;
+  --gold-deep: #b9912f;
+  --accent: var(--gold);
+  --accent-ink: #161618;  /* text on gold */
+  --green: #34c76a;
+  --blue: #4a90e2;
+  --indigo: #7c7cf0;
+  --purple: #b07ce0;
+  --red: #ef5a4f;
+  --orange: #eb9a3c;
+  --radius: 18px;
+  --shadow: 0 1px 2px rgba(0,0,0,.5), 0 6px 18px rgba(0,0,0,.28);
   --tabbar-h: 64px;
 }
 
@@ -34,7 +38,9 @@ html, body {
   max-width: 720px;
   margin: 0 auto;
   min-height: 100vh;
-  background: var(--bg);
+  background:
+    radial-gradient(120% 60% at 50% -10%, rgba(216,178,76,.10), transparent 60%),
+    var(--bg);
   position: relative;
   padding-bottom: calc(var(--tabbar-h) + env(safe-area-inset-bottom, 0px) + 12px);
 }
@@ -47,15 +53,15 @@ html, body {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 16px 12px;
-  background: color-mix(in srgb, var(--bg) 85%, transparent);
-  backdrop-filter: saturate(180%) blur(12px);
+  padding: 16px 16px 12px;
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: saturate(160%) blur(14px);
   border-bottom: 1px solid var(--line);
 }
-.appbar h1 { font-size: 22px; margin: 0; flex: 1; font-weight: 800; letter-spacing: -.02em; }
-.appbar .sub { display:block; font-size: 12px; font-weight: 600; color: var(--ink-2); }
+.appbar h1 { font-size: 22px; margin: 0; flex: 1; font-weight: 800; letter-spacing: -.02em; color: var(--ink); }
+.appbar .sub { display: block; font-size: 12px; font-weight: 600; color: var(--gold); text-transform: uppercase; letter-spacing: .08em; }
 .appbar .back {
-  border: none; background: none; color: var(--accent);
+  border: none; background: none; color: var(--gold);
   font-size: 16px; font-weight: 600; padding: 6px 4px; cursor: pointer;
 }
 
@@ -63,30 +69,36 @@ html, body {
 
 /* Buttons */
 .btn {
-  border: none; border-radius: 12px; padding: 10px 16px;
+  border: 1px solid var(--line); border-radius: 12px; padding: 10px 16px;
   font-size: 15px; font-weight: 600; cursor: pointer;
-  background: var(--card); color: var(--accent); box-shadow: var(--shadow);
+  background: var(--card-2); color: var(--gold); transition: transform .06s ease, filter .15s ease;
 }
-.btn.primary { background: var(--accent); color: var(--accent-ink); }
-.btn.ghost { background: transparent; box-shadow: none; }
-.btn.icon { padding: 8px 12px; border-radius: 999px; }
-.btn.small { padding: 6px 10px; font-size: 13px; }
+.btn.primary {
+  background: linear-gradient(180deg, var(--gold-soft), var(--gold));
+  color: var(--accent-ink); border: none;
+  box-shadow: 0 2px 10px rgba(216,178,76,.35);
+}
+.btn.ghost { background: transparent; border: none; }
+.btn.icon { padding: 9px 13px; border-radius: 999px; font-size: 17px; line-height: 1; }
+.btn.small { padding: 6px 11px; font-size: 13px; }
 .btn.danger { color: var(--red); }
 .btn:active { transform: scale(.97); }
+.btn.primary:hover { filter: brightness(1.05); }
 
 /* Cards & sections */
 .section { margin-bottom: 22px; }
 .section-head {
   display: flex; align-items: center; justify-content: space-between;
-  margin: 4px 4px 8px;
+  margin: 4px 4px 10px;
 }
 .section-head h2 {
-  font-size: 13px; font-weight: 700; text-transform: uppercase;
-  letter-spacing: .06em; color: var(--ink-2); margin: 0;
+  font-size: 12px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .1em; color: var(--ink-2); margin: 0;
 }
 .card {
   background: var(--card); border-radius: var(--radius);
   box-shadow: var(--shadow); overflow: hidden;
+  border: 1px solid var(--line);
 }
 .card.pad { padding: 16px; }
 
@@ -94,13 +106,13 @@ html, body {
 .list { list-style: none; margin: 0; padding: 0; }
 .row {
   display: flex; align-items: center; gap: 12px;
-  padding: 12px 16px; border-bottom: 1px solid var(--line);
-  cursor: pointer; background: var(--card);
+  padding: 13px 16px; border-bottom: 1px solid var(--line);
+  cursor: pointer; background: transparent;
 }
 .row:last-child { border-bottom: none; }
 .row:active { background: var(--card-2); }
 .row .grow { flex: 1; min-width: 0; }
-.row .title { font-weight: 600; }
+.row .title { font-weight: 600; color: var(--ink); }
 .row .meta { font-size: 13px; color: var(--ink-2); margin-top: 2px;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .row .trail { text-align: right; font-size: 13px; color: var(--ink-2); white-space: nowrap; }
@@ -109,15 +121,15 @@ html, body {
 .avatar {
   width: 44px; height: 44px; border-radius: 999px; flex: none;
   display: grid; place-items: center; font-weight: 700; color: #fff;
-  box-shadow: inset 0 0 0 1px rgba(0,0,0,.06);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.14);
 }
-.avatar.lg { width: 64px; height: 64px; font-size: 22px; }
+.avatar.lg { width: 64px; height: 64px; font-size: 22px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.14), 0 0 0 3px rgba(216,178,76,.18); }
 
 /* Belt badge */
 .belt {
   display: inline-flex; align-items: center; gap: 5px;
-  padding: 3px 9px; border-radius: 999px; font-size: 12px; font-weight: 700;
-  box-shadow: inset 0 0 0 1px rgba(0,0,0,.08);
+  padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 700;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.18);
 }
 .belt .stripes { display: inline-flex; gap: 2px; }
 .belt .dot { width: 4px; height: 4px; border-radius: 999px; background: currentColor; }
@@ -125,15 +137,16 @@ html, body {
 /* Status badge */
 .status {
   display: inline-flex; align-items: center; gap: 5px;
-  padding: 3px 9px; border-radius: 999px; font-size: 12px; font-weight: 600;
+  padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600;
+  background: rgba(255,255,255,.05);
 }
 .status .bullet { width: 7px; height: 7px; border-radius: 999px; background: currentColor; }
 
-/* Lesson row accent bar */
+/* Lesson row */
 .lesson-time { width: 62px; text-align: center; flex: none; }
-.lesson-time .t { font-weight: 700; font-variant-numeric: tabular-nums; }
+.lesson-time .t { font-weight: 700; font-variant-numeric: tabular-nums; color: var(--ink); }
 .lesson-time .d { font-size: 11px; color: var(--ink-2); }
-.accent-bar { width: 3px; align-self: stretch; border-radius: 999px; flex: none; }
+.accent-bar { width: 3px; align-self: stretch; border-radius: 999px; flex: none; min-height: 34px; }
 
 /* Stat tiles */
 .stats { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
@@ -141,12 +154,13 @@ html, body {
 @media (min-width: 520px) { .stats.four { grid-template-columns: repeat(4, 1fr); } }
 .stats.three { grid-template-columns: repeat(3, 1fr); }
 .tile {
-  background: var(--card); border-radius: 14px; padding: 14px;
-  box-shadow: var(--shadow);
+  background: linear-gradient(180deg, var(--card), var(--bg-2));
+  border-radius: 16px; padding: 15px;
+  box-shadow: var(--shadow); border: 1px solid var(--line);
 }
 .tile .icon { font-size: 18px; }
-.tile .val { font-size: 22px; font-weight: 800; margin-top: 6px; letter-spacing: -.02em; }
-.tile .lbl { font-size: 12px; color: var(--ink-2); margin-top: 2px; }
+.tile .val { font-size: 23px; font-weight: 800; margin-top: 8px; letter-spacing: -.02em; color: var(--ink); }
+.tile .lbl { font-size: 12px; color: var(--ink-2); margin-top: 3px; }
 
 /* Chips */
 .chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
@@ -156,8 +170,8 @@ html, body {
 }
 
 /* Empty state */
-.empty { text-align: center; color: var(--ink-2); padding: 48px 24px; }
-.empty .big { font-size: 40px; margin-bottom: 8px; }
+.empty { text-align: center; color: var(--ink-2); padding: 52px 24px; }
+.empty .big { font-size: 42px; margin-bottom: 10px; filter: grayscale(.2); }
 .empty h3 { margin: 0 0 6px; color: var(--ink); }
 
 /* Tab bar */
@@ -167,8 +181,8 @@ html, body {
   padding-bottom: env(safe-area-inset-bottom, 0px);
   max-width: 720px; margin: 0 auto;
   display: grid; grid-template-columns: repeat(4, 1fr);
-  background: color-mix(in srgb, var(--card) 88%, transparent);
-  backdrop-filter: saturate(180%) blur(14px);
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: saturate(160%) blur(16px);
   border-top: 1px solid var(--line);
 }
 .tab {
@@ -176,47 +190,49 @@ html, body {
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   gap: 3px; color: var(--ink-2); font-size: 11px; font-weight: 600;
 }
-.tab .ic { font-size: 20px; line-height: 1; }
-.tab.active { color: var(--accent); }
+.tab .ic { font-size: 20px; line-height: 1; filter: grayscale(1) opacity(.7); transition: filter .15s ease; }
+.tab.active { color: var(--gold); }
+.tab.active .ic { filter: none; }
 
 /* Segmented control */
 .segment {
-  display: inline-flex; background: var(--card-2); border-radius: 10px;
+  display: inline-flex; background: var(--bg-2); border-radius: 11px;
   padding: 3px; gap: 3px; border: 1px solid var(--line);
 }
 .segment button {
   border: none; background: none; cursor: pointer; border-radius: 8px;
-  padding: 6px 14px; font-size: 14px; font-weight: 600; color: var(--ink-2);
+  padding: 7px 16px; font-size: 14px; font-weight: 600; color: var(--ink-2);
 }
-.segment button.active { background: var(--card); color: var(--ink); box-shadow: var(--shadow); }
+.segment button.active { background: var(--card-2); color: var(--ink); box-shadow: inset 0 0 0 1px var(--line); }
 
 /* Detail header */
 .detail-head { display: flex; gap: 16px; align-items: center; }
-.detail-head .name { font-size: 20px; font-weight: 800; }
+.detail-head .name { font-size: 20px; font-weight: 800; color: var(--ink); }
 .detail-head .since { font-size: 13px; color: var(--ink-2); margin-top: 4px; }
-.contact-links { display: flex; gap: 20px; margin-top: 14px; }
-.contact-links a { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 15px; }
-.notes-text { white-space: pre-wrap; line-height: 1.5; }
+.contact-links { display: flex; gap: 20px; margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--line); }
+.contact-links a { color: var(--gold); text-decoration: none; font-weight: 600; font-size: 15px; }
+.notes-text { white-space: pre-wrap; line-height: 1.5; color: var(--ink); }
 
 /* Modal */
 .modal-backdrop {
-  position: fixed; inset: 0; z-index: 50; background: rgba(0,0,0,.4);
+  position: fixed; inset: 0; z-index: 50; background: rgba(0,0,0,.6);
   display: flex; align-items: flex-end; justify-content: center;
-  animation: fade .15s ease;
+  animation: fade .15s ease; backdrop-filter: blur(2px);
 }
 @media (min-width: 560px) { .modal-backdrop { align-items: center; } }
 .modal {
-  background: var(--bg); width: 100%; max-width: 560px;
-  border-radius: 18px 18px 0 0; max-height: 92vh; overflow-y: auto;
-  animation: slideup .2s ease;
+  background: var(--bg-2); width: 100%; max-width: 560px;
+  border-radius: 20px 20px 0 0; max-height: 92vh; overflow-y: auto;
+  border: 1px solid var(--line);
+  animation: slideup .22s ease;
 }
-@media (min-width: 560px) { .modal { border-radius: 18px; } }
+@media (min-width: 560px) { .modal { border-radius: 20px; } }
 .modal .modal-bar {
-  position: sticky; top: 0; background: var(--bg); z-index: 2;
+  position: sticky; top: 0; background: var(--bg-2); z-index: 2;
   display: flex; align-items: center; justify-content: space-between;
   padding: 14px 16px; border-bottom: 1px solid var(--line);
 }
-.modal .modal-bar h2 { font-size: 17px; margin: 0; }
+.modal .modal-bar h2 { font-size: 17px; margin: 0; color: var(--ink); }
 .modal form { padding: 16px; }
 
 /* Form fields */
@@ -224,17 +240,19 @@ html, body {
 .field label { display: block; font-size: 13px; font-weight: 600; color: var(--ink-2); margin-bottom: 6px; }
 .field input, .field select, .field textarea {
   width: 100%; padding: 12px; border-radius: 12px; border: 1px solid var(--line);
-  background: var(--card); color: var(--ink); font-size: 16px; font-family: inherit;
+  background: var(--card-2); color: var(--ink); font-size: 16px; font-family: inherit;
+  transition: border-color .15s ease, box-shadow .15s ease;
 }
+.field input:focus, .field select:focus, .field textarea:focus {
+  outline: none; border-color: var(--gold);
+  box-shadow: 0 0 0 3px rgba(216,178,76,.18);
+}
+.field input::placeholder, .field textarea::placeholder { color: #6c6c75; }
 .field textarea { resize: vertical; min-height: 70px; }
 .field-row { display: flex; gap: 12px; }
 .field-row > .field { flex: 1; }
-.stepper { display: flex; align-items: center; gap: 12px; }
-.stepper button {
-  width: 36px; height: 36px; border-radius: 999px; border: 1px solid var(--line);
-  background: var(--card); font-size: 20px; cursor: pointer; line-height: 1;
-}
 .toggle-row { display: flex; align-items: center; justify-content: space-between; }
+.field input[type="checkbox"] { accent-color: var(--gold); width: 22px; height: 22px; }
 
 @keyframes fade { from { opacity: 0 } to { opacity: 1 } }
 @keyframes slideup { from { transform: translateY(24px); opacity: .5 } to { transform: none; opacity: 1 } }
@@ -245,3 +263,7 @@ html, body {
 .danger-text { color: var(--red); }
 .center { text-align: center; }
 .pill-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+/* Native form controls dark */
+select option { background: var(--card-2); color: var(--ink); }
+input[type="date"], input[type="datetime-local"] { color-scheme: dark; }

--- a/static/lesson-tracker/styles.css
+++ b/static/lesson-tracker/styles.css
@@ -1,0 +1,247 @@
+:root {
+  --bg: #f2f2f7;
+  --card: #ffffff;
+  --card-2: #f7f7fa;
+  --ink: #1c1c1e;
+  --ink-2: #6b6b70;
+  --line: #e4e4e9;
+  --accent: #1a6b3c;       /* mat green */
+  --accent-ink: #ffffff;
+  --green: #2e9e54;
+  --blue: #2b78e4;
+  --indigo: #5b5bd6;
+  --purple: #8944c4;
+  --red: #e0483d;
+  --orange: #e88b2a;
+  --radius: 16px;
+  --shadow: 0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+  --tabbar-h: 64px;
+}
+
+* { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+}
+
+#app {
+  max-width: 720px;
+  margin: 0 auto;
+  min-height: 100vh;
+  background: var(--bg);
+  position: relative;
+  padding-bottom: calc(var(--tabbar-h) + env(safe-area-inset-bottom, 0px) + 12px);
+}
+
+/* App bar */
+.appbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px 12px;
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--line);
+}
+.appbar h1 { font-size: 22px; margin: 0; flex: 1; font-weight: 800; letter-spacing: -.02em; }
+.appbar .sub { display:block; font-size: 12px; font-weight: 600; color: var(--ink-2); }
+.appbar .back {
+  border: none; background: none; color: var(--accent);
+  font-size: 16px; font-weight: 600; padding: 6px 4px; cursor: pointer;
+}
+
+.content { padding: 16px; }
+
+/* Buttons */
+.btn {
+  border: none; border-radius: 12px; padding: 10px 16px;
+  font-size: 15px; font-weight: 600; cursor: pointer;
+  background: var(--card); color: var(--accent); box-shadow: var(--shadow);
+}
+.btn.primary { background: var(--accent); color: var(--accent-ink); }
+.btn.ghost { background: transparent; box-shadow: none; }
+.btn.icon { padding: 8px 12px; border-radius: 999px; }
+.btn.small { padding: 6px 10px; font-size: 13px; }
+.btn.danger { color: var(--red); }
+.btn:active { transform: scale(.97); }
+
+/* Cards & sections */
+.section { margin-bottom: 22px; }
+.section-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin: 4px 4px 8px;
+}
+.section-head h2 {
+  font-size: 13px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .06em; color: var(--ink-2); margin: 0;
+}
+.card {
+  background: var(--card); border-radius: var(--radius);
+  box-shadow: var(--shadow); overflow: hidden;
+}
+.card.pad { padding: 16px; }
+
+/* Lists */
+.list { list-style: none; margin: 0; padding: 0; }
+.row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px; border-bottom: 1px solid var(--line);
+  cursor: pointer; background: var(--card);
+}
+.row:last-child { border-bottom: none; }
+.row:active { background: var(--card-2); }
+.row .grow { flex: 1; min-width: 0; }
+.row .title { font-weight: 600; }
+.row .meta { font-size: 13px; color: var(--ink-2); margin-top: 2px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.row .trail { text-align: right; font-size: 13px; color: var(--ink-2); white-space: nowrap; }
+
+/* Avatar */
+.avatar {
+  width: 44px; height: 44px; border-radius: 999px; flex: none;
+  display: grid; place-items: center; font-weight: 700; color: #fff;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,.06);
+}
+.avatar.lg { width: 64px; height: 64px; font-size: 22px; }
+
+/* Belt badge */
+.belt {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 9px; border-radius: 999px; font-size: 12px; font-weight: 700;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,.08);
+}
+.belt .stripes { display: inline-flex; gap: 2px; }
+.belt .dot { width: 4px; height: 4px; border-radius: 999px; background: currentColor; }
+
+/* Status badge */
+.status {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 9px; border-radius: 999px; font-size: 12px; font-weight: 600;
+}
+.status .bullet { width: 7px; height: 7px; border-radius: 999px; background: currentColor; }
+
+/* Lesson row accent bar */
+.lesson-time { width: 62px; text-align: center; flex: none; }
+.lesson-time .t { font-weight: 700; font-variant-numeric: tabular-nums; }
+.lesson-time .d { font-size: 11px; color: var(--ink-2); }
+.accent-bar { width: 3px; align-self: stretch; border-radius: 999px; flex: none; }
+
+/* Stat tiles */
+.stats { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.stats.four { grid-template-columns: repeat(2, 1fr); }
+@media (min-width: 520px) { .stats.four { grid-template-columns: repeat(4, 1fr); } }
+.stats.three { grid-template-columns: repeat(3, 1fr); }
+.tile {
+  background: var(--card); border-radius: 14px; padding: 14px;
+  box-shadow: var(--shadow);
+}
+.tile .icon { font-size: 18px; }
+.tile .val { font-size: 22px; font-weight: 800; margin-top: 6px; letter-spacing: -.02em; }
+.tile .lbl { font-size: 12px; color: var(--ink-2); margin-top: 2px; }
+
+/* Chips */
+.chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+.chip {
+  font-size: 12px; padding: 3px 8px; border-radius: 8px;
+  background: var(--card-2); color: var(--ink-2); border: 1px solid var(--line);
+}
+
+/* Empty state */
+.empty { text-align: center; color: var(--ink-2); padding: 48px 24px; }
+.empty .big { font-size: 40px; margin-bottom: 8px; }
+.empty h3 { margin: 0 0 6px; color: var(--ink); }
+
+/* Tab bar */
+.tabbar {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 30;
+  height: calc(var(--tabbar-h) + env(safe-area-inset-bottom, 0px));
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  max-width: 720px; margin: 0 auto;
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  background: color-mix(in srgb, var(--card) 88%, transparent);
+  backdrop-filter: saturate(180%) blur(14px);
+  border-top: 1px solid var(--line);
+}
+.tab {
+  border: none; background: none; cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 3px; color: var(--ink-2); font-size: 11px; font-weight: 600;
+}
+.tab .ic { font-size: 20px; line-height: 1; }
+.tab.active { color: var(--accent); }
+
+/* Segmented control */
+.segment {
+  display: inline-flex; background: var(--card-2); border-radius: 10px;
+  padding: 3px; gap: 3px; border: 1px solid var(--line);
+}
+.segment button {
+  border: none; background: none; cursor: pointer; border-radius: 8px;
+  padding: 6px 14px; font-size: 14px; font-weight: 600; color: var(--ink-2);
+}
+.segment button.active { background: var(--card); color: var(--ink); box-shadow: var(--shadow); }
+
+/* Detail header */
+.detail-head { display: flex; gap: 16px; align-items: center; }
+.detail-head .name { font-size: 20px; font-weight: 800; }
+.detail-head .since { font-size: 13px; color: var(--ink-2); margin-top: 4px; }
+.contact-links { display: flex; gap: 20px; margin-top: 14px; }
+.contact-links a { color: var(--accent); text-decoration: none; font-weight: 600; font-size: 15px; }
+.notes-text { white-space: pre-wrap; line-height: 1.5; }
+
+/* Modal */
+.modal-backdrop {
+  position: fixed; inset: 0; z-index: 50; background: rgba(0,0,0,.4);
+  display: flex; align-items: flex-end; justify-content: center;
+  animation: fade .15s ease;
+}
+@media (min-width: 560px) { .modal-backdrop { align-items: center; } }
+.modal {
+  background: var(--bg); width: 100%; max-width: 560px;
+  border-radius: 18px 18px 0 0; max-height: 92vh; overflow-y: auto;
+  animation: slideup .2s ease;
+}
+@media (min-width: 560px) { .modal { border-radius: 18px; } }
+.modal .modal-bar {
+  position: sticky; top: 0; background: var(--bg); z-index: 2;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 16px; border-bottom: 1px solid var(--line);
+}
+.modal .modal-bar h2 { font-size: 17px; margin: 0; }
+.modal form { padding: 16px; }
+
+/* Form fields */
+.field { margin-bottom: 16px; }
+.field label { display: block; font-size: 13px; font-weight: 600; color: var(--ink-2); margin-bottom: 6px; }
+.field input, .field select, .field textarea {
+  width: 100%; padding: 12px; border-radius: 12px; border: 1px solid var(--line);
+  background: var(--card); color: var(--ink); font-size: 16px; font-family: inherit;
+}
+.field textarea { resize: vertical; min-height: 70px; }
+.field-row { display: flex; gap: 12px; }
+.field-row > .field { flex: 1; }
+.stepper { display: flex; align-items: center; gap: 12px; }
+.stepper button {
+  width: 36px; height: 36px; border-radius: 999px; border: 1px solid var(--line);
+  background: var(--card); font-size: 20px; cursor: pointer; line-height: 1;
+}
+.toggle-row { display: flex; align-items: center; justify-content: space-between; }
+
+@keyframes fade { from { opacity: 0 } to { opacity: 1 } }
+@keyframes slideup { from { transform: translateY(24px); opacity: .5 } to { transform: none; opacity: 1 } }
+
+.muted { color: var(--ink-2); }
+.right { text-align: right; }
+.spacer { flex: 1; }
+.danger-text { color: var(--red); }
+.center { text-align: center; }
+.pill-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }


### PR DESCRIPTION
Native iOS app for BJJ instructors to manage private lessons:
- Client profiles: belt rank, stripes, contact, rate, notes
- Lesson log with status-based attendance (scheduled/completed/cancelled/no-show)
- Schedule grouped by day with swipe-to-complete
- Payments with package tracking and monthly/all-time revenue
- "Today" dashboard with quick stats
- SwiftData persistence; on-device by default with optional CloudKit sync
- Seeds sample data on first launch; builds and runs in the Simulator with
  zero configuration (Xcode 16+, iOS 17+)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012HPFbNmC44ReztZV7JiyBa